### PR TITLE
[FEAT] krnl: Fix the boot and loader paths.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ build/
 
 vmkrnl.exe
 bootzldr.exe
+private/minloader/src/root/ne_kernel
 
 tools/dist/mkfs.*
 tools/dist/fsck.*

--- a/private/libSystem/src/System.cpp
+++ b/private/libSystem/src/System.cpp
@@ -228,8 +228,8 @@ IMPORT_C UInt64 PrintSize(IORef ref) {
 }
 
 IMPORT_C SInt32 ThrExitMainThread(SInt32 exit_code) {
-  nesys_syscall_arg_2(SYSCALL_HASH("ThrExitMainThread"), reinterpret_cast<VoidPtr>(
-                                                             static_cast<UIntPtr>(exit_code)));
+  nesys_syscall_arg_2(SYSCALL_HASH("ThrExitMainThread"),
+                      reinterpret_cast<VoidPtr>(static_cast<UIntPtr>(exit_code)));
 
   while (YES) {
   }

--- a/private/libSystem/src/System.cpp
+++ b/private/libSystem/src/System.cpp
@@ -226,3 +226,13 @@ IMPORT_C SInt32 PrintOut(_Input IORef desc, const Char* fmt, ...) {
 IMPORT_C UInt64 PrintSize(IORef ref) {
   return *static_cast<UInt64*>(nesys_syscall_arg_2(SYSCALL_HASH("PrintSize"), ref));
 }
+
+IMPORT_C SInt32 ThrExitMainThread(SInt32 exit_code) {
+  nesys_syscall_arg_2(SYSCALL_HASH("ThrExitMainThread"), reinterpret_cast<VoidPtr>(
+                                                             static_cast<UIntPtr>(exit_code)));
+
+  while (YES) {
+  }
+
+  return exit_code;
+}

--- a/private/libSystem/src/SystemABI+AMD64.asm
+++ b/private/libSystem/src/SystemABI+AMD64.asm
@@ -16,15 +16,17 @@ global nesys_syscall_arg_2
 global nesys_syscall_arg_3
 global nesys_syscall_arg_4
 
+;; Win64 in: rcx = hash, rdx/r8/r9 = args.
+;; Kernel expects: r8 = hash, r9/r10/r11 = args. Move high to low so nothing is clobbered.
+;; Result comes back in rax.
+
 nesys_syscall_arg_1:
     push rbp
     mov rbp, rsp
 
     mov r8, rcx
 
-    xor rax, rax
-
-    syscall
+    int 0x32
 
     pop rbp
 
@@ -34,12 +36,10 @@ nesys_syscall_arg_2:
     push rbp
     mov rbp, rsp
 
-    mov r8, rcx
     mov r9, rdx
+    mov r8, rcx
 
-    xor rax, rax
-
-    syscall
+    int 0x32
 
     pop rbp
 
@@ -49,13 +49,11 @@ nesys_syscall_arg_3:
     push rbp
     mov rbp, rsp
 
-    mov r8, rcx
+    mov r10, r8
     mov r9, rdx
-    mov r10, rbx
+    mov r8, rcx
 
-    xor rax, rax
-
-    syscall
+    int 0x32
 
     pop rbp
 
@@ -65,16 +63,12 @@ nesys_syscall_arg_4:
     push rbp
     mov rbp, rsp
 
-    mov rax, r8
-
-    mov r8, rcx
+    mov r11, r9
+    mov r10, r8
     mov r9, rdx
-    mov r10, rbx
-    mov r11, rax
+    mov r8, rcx
 
-    xor rax, rax
-
-    syscall
+    int 0x32
 
     pop rbp
 

--- a/private/minkernel/ArchKit/ArchKit.h
+++ b/private/minkernel/ArchKit/ArchKit.h
@@ -67,7 +67,7 @@ namespace HAL {
 }  // namespace HAL
 }  // namespace Ne::Kernel
 
-using rt_syscall_proc = Ne::Kernel::Void (*)(Ne::Kernel::VoidPtr);
+using rt_syscall_proc = Ne::Kernel::VoidPtr (*)(Ne::Kernel::VoidPtr);
 
 /// @brief System Call Dispatch.
 struct HAL_DISPATCH_ENTRY final {
@@ -98,6 +98,64 @@ struct HAL_KERNEL_DISPATCH_ENTRY final {
 inline Ne::Kernel::Array<HAL_DISPATCH_ENTRY, kMaxDispatchCallCount> kSysCalls;
 
 inline Ne::Kernel::Array<HAL_KERNEL_DISPATCH_ENTRY, kMaxDispatchCallCount> kKernCalls;
+
+/// @brief FNV-64 of a call name.
+/// @note must stay bit for bit identical to libSystem's nesys_hash_64.
+inline Ne::Kernel::UInt64 ke_hash_64(const Ne::Kernel::Char* name) {
+  if (!name || *name == 0) return 0;
+
+  const Ne::Kernel::UInt64 kFNVSeed  = 0xcbf29ce484222325ULL;
+  const Ne::Kernel::UInt64 kFNVPrime = 0x100000001b3ULL;
+
+  Ne::Kernel::UInt64 hash = kFNVSeed;
+
+  while (*name) {
+    hash ^= (Ne::Kernel::Char) (*name++);
+    hash *= kFNVPrime;
+  }
+
+  return hash;
+}
+
+/// @brief Bind a system call to a free dispatch slot.
+/// @return the slot it took, -1 when the table is full.
+inline Ne::Kernel::SSizeT ke_install_syscall(const Ne::Kernel::Char* name, rt_syscall_proc proc) {
+  auto hash = ke_hash_64(name);
+
+  if (!hash || !proc) return -1;
+
+  for (Ne::Kernel::SizeT i = 0UL; i < kMaxDispatchCallCount; ++i) {
+    if (kSysCalls[i].fHooked) continue;
+
+    kSysCalls[i].fHash   = hash;
+    kSysCalls[i].fProc   = proc;
+    kSysCalls[i].fHooked = YES;
+
+    return i;
+  }
+
+  return -1;
+}
+
+/// @brief Bind a kernel call to a free dispatch slot.
+/// @return the slot it took, -1 when the table is full.
+inline Ne::Kernel::SSizeT ke_install_kerncall(const Ne::Kernel::Char* name, rt_kerncall_proc proc) {
+  auto hash = ke_hash_64(name);
+
+  if (!hash || !proc) return -1;
+
+  for (Ne::Kernel::SizeT i = 0UL; i < kMaxDispatchCallCount; ++i) {
+    if (kKernCalls[i].fHooked) continue;
+
+    kKernCalls[i].fHash   = hash;
+    kKernCalls[i].fProc   = proc;
+    kKernCalls[i].fHooked = YES;
+
+    return i;
+  }
+
+  return -1;
+}
 
 #ifdef __NE_VIRTUAL_MEMORY_SUPPORT__
 

--- a/private/minkernel/FSKit/OpenHeFS.h
+++ b/private/minkernel/FSKit/OpenHeFS.h
@@ -416,6 +416,9 @@ class HeFileSystemParser final {
                           const Utf8Char* dir, const Utf8Char* name, const UInt8 kind,
                           const BOOL input);
 
+  _Output Bool INodeExists(_Input DriveTrait* drive, const Utf8Char* dir, const Utf8Char* name,
+                           const UInt8 kind);
+
  private:
   _Output Bool INodeCtlManip(_Input DriveTrait* drive, _Input const Int32 flags,
                              const Utf8Char* dir, const Utf8Char* name, const BOOL delete_or_create,

--- a/private/minkernel/FirmwareKit/EFI/EFI.h
+++ b/private/minkernel/FirmwareKit/EFI/EFI.h
@@ -468,8 +468,7 @@ typedef UInt64(EFI_API* EfiFreePages)(EfiPhysicalAddress* Memory, UIntPtr Pages)
 
 /// @note UEFI types these as UINTN*, the firmware writes 8 bytes through each.
 typedef UInt64(EFI_API* EfiGetMemoryMap)(UIntPtr* MapSize, EfiMemoryDescriptor* DescPtr,
-                                         UIntPtr* MapKey, UIntPtr* DescSize,
-                                         UIntPtr* DescVersion);
+                                         UIntPtr* MapKey, UIntPtr* DescSize, UIntPtr* DescVersion);
 
 /**
  * @brief GUID type, something you can also find in CFKit.

--- a/private/minkernel/FirmwareKit/EFI/EFI.h
+++ b/private/minkernel/FirmwareKit/EFI/EFI.h
@@ -609,11 +609,12 @@ struct EfiSimpleFilesystemProtocol {
 typedef struct EfiRuntimeServices {
   EfiTableHeader SystemTable;
   VoidPtr GetTime, SetTime, GetWakeupTime, SetWakeupTime, SetVirtualAddressMap, ConvertPointer;
+  /// @note DataSize is in/out and UEFI types it as UINTN*, the firmware writes 8 bytes.
   UInt64(EFI_API* GetVariable)(const WideChar* Name, EFI_GUID VendorGUID, UInt32* Attributes,
-                               UInt32* DataSize, VoidPtr Data);
+                               UIntPtr* DataSize, VoidPtr Data);
   VoidPtr GetNextVariable;
-  UInt64(EFI_API* SetVariable)(const WideChar* Name, EFI_GUID VendorGUID, UInt32* Attributes,
-                               UInt32* DataSize, VoidPtr Data);
+  UInt64(EFI_API* SetVariable)(const WideChar* Name, EFI_GUID VendorGUID, UInt32 Attributes,
+                               UIntPtr DataSize, VoidPtr Data);
   VoidPtr GetNextHighMonotonicCount;
   VoidPtr ResetSystem;
   VoidPtr UpdateCapsule;

--- a/private/minkernel/FirmwareKit/EFI/EFI.h
+++ b/private/minkernel/FirmwareKit/EFI/EFI.h
@@ -462,9 +462,9 @@ typedef struct EfiFileDevicePathProtocol {
 typedef UInt64(EFI_API* EfiExitBootServices)(VoidPtr ImageHandle, UIntPtr MapKey);
 
 typedef UInt64(EFI_API* EfiAllocatePages)(EfiAllocateType AllocType, EfiMemoryType MemType,
-                                          UInt32 Count, EfiPhysicalAddress* Memory);
+                                          UIntPtr Count, EfiPhysicalAddress* Memory);
 
-typedef UInt64(EFI_API* EfiFreePages)(EfiPhysicalAddress* Memory, UInt32 Pages);
+typedef UInt64(EFI_API* EfiFreePages)(EfiPhysicalAddress* Memory, UIntPtr Pages);
 
 /// @note UEFI types these as UINTN*, the firmware writes 8 bytes through each.
 typedef UInt64(EFI_API* EfiGetMemoryMap)(UIntPtr* MapSize, EfiMemoryDescriptor* DescPtr,

--- a/private/minkernel/FirmwareKit/EFI/EFI.h
+++ b/private/minkernel/FirmwareKit/EFI/EFI.h
@@ -221,7 +221,7 @@ typedef struct EfiMemoryDescriptor {
   UInt64 Attribute;
 } EfiMemoryDescriptor;
 
-typedef UInt64(EFI_API* EfiAllocatePool)(EfiMemoryType PoolType, UInt32 Size, VoidPtr* Buffer);
+typedef UInt64(EFI_API* EfiAllocatePool)(EfiMemoryType PoolType, UIntPtr Size, VoidPtr* Buffer);
 
 typedef UInt64(EFI_API* EfiFreePool)(VoidPtr Buffer);
 
@@ -459,15 +459,17 @@ typedef struct EfiFileDevicePathProtocol {
   WideChar Path[kPathLen];
 } EfiFileDevicePathProtocol;
 
-typedef UInt64(EFI_API* EfiExitBootServices)(VoidPtr ImageHandle, UInt32 MapKey);
+typedef UInt64(EFI_API* EfiExitBootServices)(VoidPtr ImageHandle, UIntPtr MapKey);
 
 typedef UInt64(EFI_API* EfiAllocatePages)(EfiAllocateType AllocType, EfiMemoryType MemType,
                                           UInt32 Count, EfiPhysicalAddress* Memory);
 
 typedef UInt64(EFI_API* EfiFreePages)(EfiPhysicalAddress* Memory, UInt32 Pages);
 
-typedef UInt64(EFI_API* EfiGetMemoryMap)(UInt32* MapSize, EfiMemoryDescriptor* DescPtr,
-                                         UInt32* MapKey, UInt32* DescSize, UInt32* DescVersion);
+/// @note UEFI types these as UINTN*, the firmware writes 8 bytes through each.
+typedef UInt64(EFI_API* EfiGetMemoryMap)(UIntPtr* MapSize, EfiMemoryDescriptor* DescPtr,
+                                         UIntPtr* MapKey, UIntPtr* DescSize,
+                                         UIntPtr* DescVersion);
 
 /**
  * @brief GUID type, something you can also find in CFKit.

--- a/private/minkernel/FirmwareKit/Handover.h
+++ b/private/minkernel/FirmwareKit/Handover.h
@@ -71,7 +71,7 @@ struct BootInfoHeader final {
     VoidPtr      f_VendorPtr;
     VoidPtr      f_MpPtr;
     Bool         f_MultiProcessingEnabled;
-    UInt32       f_ImageKey;
+    UIntPtr      f_ImageKey;
     EfiHandlePtr f_ImageHandle;
   } f_HardwareTables;
 

--- a/private/minkernel/HALKit/AMD64/CxxAbi.cpp
+++ b/private/minkernel/HALKit/AMD64/CxxAbi.cpp
@@ -22,15 +22,6 @@ EXTERN_C Ne::Kernel::Void __cxa_pure_virtual(void* self) {
   (Ne::Kernel::Void)(Ne::Kernel::kout << ", has unimplemented virtual functions.\r");
 }
 
-EXTERN_C void ___chkstk_ms(PtrDiff frame_size) {
-  char* sp;
-  asm volatile("mov %%rsp, %0" : "=r"(sp));
-
-  for (PtrDiff offset = kPageSize; offset < frame_size; offset += kPageSize) {
-    sp[-offset] = 0;
-  }
-}
-
 EXTERN_C int atexit(void (*f)()) {
   if (__atexit_func_count >= kAtExitMaxDestructors) return 1;
 

--- a/private/minkernel/HALKit/AMD64/CxxAbi.cpp
+++ b/private/minkernel/HALKit/AMD64/CxxAbi.cpp
@@ -62,15 +62,18 @@ EXTERN_C void __cxa_finalize(void* f) {
 }
 
 namespace cxxabiv1 {
+/// @note returns 1 when the caller still has to run the constructor, 0 when it is done.
 EXTERN_C int __cxa_guard_acquire(__guard g) {
-  if ((*g & 1) || (*g & 2)) return 1;
+  if (*g & 1) return 0;
+
   *g |= 2;
-  return 0;
+
+  return 1;
 }
 
 EXTERN_C void __cxa_guard_release(__guard g) {
   *g |= 1;
-  *g &= 2;
+  *g &= ~2;
 }
 
 EXTERN_C void __cxa_guard_abort(__guard g) {

--- a/private/minkernel/HALKit/AMD64/HalCommonAPI.asm
+++ b/private/minkernel/HALKit/AMD64/HalCommonAPI.asm
@@ -127,3 +127,34 @@ sched_recover_registers:
 
     ret
 
+
+;; Stack probe emitted by GCC for large frames.
+;; RAX holds the frame size on entry and the caller does 'sub rax, rsp'
+;; right after, so every register including RAX has to survive.
+
+global ___chkstk_ms
+
+___chkstk_ms:
+    push rcx
+    push rax
+
+    cmp rax, 0x1000
+    lea rcx, [rsp + 24]
+    jb .last
+
+.probe:
+    sub rcx, 0x1000
+    or qword [rcx], 0
+
+    sub rax, 0x1000
+    cmp rax, 0x1000
+    ja .probe
+
+.last:
+    sub rcx, rax
+    or qword [rcx], 0
+
+    pop rax
+    pop rcx
+
+    ret

--- a/private/minkernel/HALKit/AMD64/HalCoreInterruptHandler.cpp
+++ b/private/minkernel/HALKit/AMD64/HalCoreInterruptHandler.cpp
@@ -142,19 +142,19 @@ EXTERN_C void idt_handle_ud(Ne::Kernel::UIntPtr rsp) {
 /// @brief Enter syscall from assembly (libSystem only)
 /// @param stack the stack pushed from assembly routine.
 /// @return nothing.
-EXTERN_C Ne::Kernel::Void hal_system_call_enter(Ne::Kernel::UIntPtr rcx_hash,
-                                            Ne::Kernel::UIntPtr rdx_syscall_arg) {
-  hal_idt_send_eoi(50);
-
-  if (!Ne::Kernel::kCurrentUser) return;
+EXTERN_C Ne::Kernel::VoidPtr hal_system_call_enter(Ne::Kernel::UIntPtr rcx_hash,
+                                                   Ne::Kernel::UIntPtr rdx_syscall_arg) {
+  if (!Ne::Kernel::kCurrentUser) return nullptr;
 
   for (SizeT i = 0UL; i < kMaxDispatchCallCount; ++i) {
     if (kSysCalls[i].fHooked && rcx_hash == kSysCalls[i].fHash) {
-      if (kSysCalls[i].fProc) {
-        (kSysCalls[i].fProc)((Ne::Kernel::VoidPtr) rdx_syscall_arg);
-      }
+      if (!kSysCalls[i].fProc) break;
+
+      return (kSysCalls[i].fProc)((Ne::Kernel::VoidPtr) rdx_syscall_arg);
     }
   }
+
+  return nullptr;
 }
 
 /// @brief Enter Ne::Kernel call from assembly (libDDK only).

--- a/private/minkernel/HALKit/AMD64/HalDescriptorLoader.cpp
+++ b/private/minkernel/HALKit/AMD64/HalDescriptorLoader.cpp
@@ -11,6 +11,11 @@ namespace Ne::Kernel::HAL {
 namespace Detail {
   STATIC ::Ne::Kernel::Detail::AMD64::InterruptDescriptorAMD64 kInterruptVectorTable[kKernelIdtSize] =
       {};
+
+  /// @brief Is this vector callable from ring 3?
+  STATIC Bool idt_is_user_gate(const SizeT vec) {
+    return vec == kKernelInterruptId || vec == kKernelCallId;
+  }
 }  // namespace Detail
 
 /// @brief Loads the provided Global Descriptor Table.
@@ -34,7 +39,7 @@ Void IDTLoader::Load(Register64& idt) {
     Detail::kInterruptVectorTable[idt_indx].Selector = kIDTSelector;
     Detail::kInterruptVectorTable[idt_indx].Ist      = 0;
     Detail::kInterruptVectorTable[idt_indx].TypeAttributes =
-        (idt_indx == kKernelInterruptId || idt_indx == (kKernelInterruptId + 1)) ? kUserInterruptGate : kInterruptGate;
+        Detail::idt_is_user_gate(idt_indx) ? kUserInterruptGate : kInterruptGate;
     Detail::kInterruptVectorTable[idt_indx].OffsetLow = ((UIntPtr) ptr_ivt[idt_indx] & 0xFFFF);
     Detail::kInterruptVectorTable[idt_indx].OffsetMid =
         (((UIntPtr) ptr_ivt[idt_indx] >> 16) & 0xFFFF);

--- a/private/minkernel/HALKit/AMD64/HalDescriptorLoader.cpp
+++ b/private/minkernel/HALKit/AMD64/HalDescriptorLoader.cpp
@@ -16,6 +16,11 @@ namespace Detail {
   STATIC Bool idt_is_user_gate(const SizeT vec) {
     return vec == kKernelInterruptId || vec == kKernelCallId;
   }
+
+  /// @brief Faults that must not run on a possibly exhausted stack.
+  STATIC UInt8 idt_stack_of(const SizeT vec) {
+    return (vec == kDoubleFaultId || vec == kPageFaultId) ? kFaultStackId : 0;
+  }
 }  // namespace Detail
 
 /// @brief Loads the provided Global Descriptor Table.
@@ -37,7 +42,7 @@ Void IDTLoader::Load(Register64& idt) {
 
   for (SizeT idt_indx = 0; idt_indx < kKernelIdtSize; ++idt_indx) {
     Detail::kInterruptVectorTable[idt_indx].Selector = kIDTSelector;
-    Detail::kInterruptVectorTable[idt_indx].Ist      = 0;
+    Detail::kInterruptVectorTable[idt_indx].Ist      = Detail::idt_stack_of(idt_indx);
     Detail::kInterruptVectorTable[idt_indx].TypeAttributes =
         Detail::idt_is_user_gate(idt_indx) ? kUserInterruptGate : kInterruptGate;
     Detail::kInterruptVectorTable[idt_indx].OffsetLow = ((UIntPtr) ptr_ivt[idt_indx] & 0xFFFF);

--- a/private/minkernel/HALKit/AMD64/HalInterruptAPI.asm
+++ b/private/minkernel/HALKit/AMD64/HalInterruptAPI.asm
@@ -8,6 +8,7 @@
 %define kInterruptId 50
 
 ;; Exception that the CPU pushes an error code for, drop it before iret.
+;; The error code is one qword; iret pops the rest of the frame itself.
 %macro IntExp 1
 global __NE_INT_%1
 __NE_INT_%1:
@@ -15,14 +16,18 @@ __NE_INT_%1:
 
     add rsp, 8
 
+    std
+
     o64 iret
 %endmacro
 
-;; Interrupt without an error code.
+;; Interrupt without an error code, the frame is already iret shaped.
 %macro IntNormal 1
 global __NE_INT_%1
 __NE_INT_%1:
     cli
+
+    std
 
     o64 iret
 %endmacro

--- a/private/minkernel/HALKit/AMD64/HalInterruptAPI.asm
+++ b/private/minkernel/HALKit/AMD64/HalInterruptAPI.asm
@@ -254,39 +254,46 @@ IntNormal 49
 [extern hal_system_call_enter]
 [extern hal_kernel_call_enter]
 
+; rax carries the handler's result back to the caller, so it is never restored.
 __NE_INT_50:
     cli
 
-    push rax
-    mov rax, hal_system_call_enter
+    push rbp
+    mov rbp, rsp
 
     mov rcx, r8
     mov rdx, r9
     mov r8, r10
     mov r9, r11
 
-    call rax
-    pop rax
+    and rsp, -16
+    sub rsp, 32
 
-    std
+    call hal_system_call_enter
+
+    mov rsp, rbp
+    pop rbp
 
     o64 iret
 
 __NE_INT_51:
     cli
 
-    push rax
-    mov rax, hal_kernel_call_enter
+    push rbp
+    mov rbp, rsp
 
     mov rcx, r8
     mov rdx, r9
     mov r8, r10
     mov r9, r11
 
-    call rax
-    pop rax
+    and rsp, -16
+    sub rsp, 32
 
-    std
+    call hal_kernel_call_enter
+
+    mov rsp, rbp
+    pop rbp
 
     o64 iret
 

--- a/private/minkernel/HALKit/AMD64/HalInterruptAPI.asm
+++ b/private/minkernel/HALKit/AMD64/HalInterruptAPI.asm
@@ -7,24 +7,22 @@
 
 %define kInterruptId 50
 
+;; Exception that the CPU pushes an error code for, drop it before iret.
 %macro IntExp 1
 global __NE_INT_%1
 __NE_INT_%1:
     cli
 
-    std
+    add rsp, 8
 
     o64 iret
 %endmacro
 
+;; Interrupt without an error code.
 %macro IntNormal 1
 global __NE_INT_%1
 __NE_INT_%1:
     cli
-
-    std
-    
-    add rsp, 8
 
     o64 iret
 %endmacro
@@ -132,7 +130,7 @@ __NE_INT_8:
     call idt_handle_math
     pop rcx
 
-    std
+    add rsp, 8
 
     o64 iret
 
@@ -149,8 +147,6 @@ __NE_INT_13:
     call idt_handle_gpf
     pop rcx
 
-    std
-    
     add rsp, 8
 
     o64 iret
@@ -161,7 +157,7 @@ __NE_INT_14:
     call idt_handle_pf
     pop rcx
 
-    std
+    add rsp, 8
 
     o64 iret
 
@@ -171,7 +167,7 @@ IntExp 17
 IntNormal 18
 IntNormal 19
 IntNormal 20
-IntNormal 21
+IntExp    21
 
 IntNormal 22
 
@@ -181,7 +177,7 @@ IntNormal 25
 IntNormal 26
 IntNormal 27
 IntNormal 28
-IntNormal 29
+IntExp    29
 IntExp    30
 IntNormal 31
 

--- a/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
+++ b/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
@@ -69,7 +69,10 @@ EXTERN_C Ne::Kernel::Int32 hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* ha
     ke_stop(RUNTIME_CHECK_BOOTSTRAP, "No ring 0 stack in handover.");
   }
 
+  STATIC UInt8 ALIGN(0x10) kFaultStack[kib_cast(32)]{};
+
   kKernelTSS.fRsp0 = (UInt64) kHandoverHeader->f_StackTop;
+  kKernelTSS.fIst1 = (UInt64) (kFaultStack + sizeof(kFaultStack)) & ~0xFUL;
   kKernelTSS.fIopb = sizeof(HAL::Detail::NE_TSS);
 
   /* The GDT, mostly descriptors for user and kernel segments. */

--- a/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
+++ b/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
@@ -26,7 +26,7 @@ EXTERN_C Ne::Kernel::VoidPtr kInterruptVectorTable[];
 EXTERN_C Ne::Kernel::Int32 hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* handover_hdr) {
   using namespace Ne::Kernel;
 
-  if (handover_hdr->f_Magic != kHandoverMagic && handover_hdr->f_Version != kHandoverVersion) {
+  if (handover_hdr->f_Magic != kHandoverMagic || handover_hdr->f_Version != kHandoverVersion) {
     return kEfiFail;
   }
 
@@ -64,6 +64,10 @@ EXTERN_C Ne::Kernel::Int32 hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* ha
   STATIC CONST auto kGDTEntriesCount = 8;
 
   STATIC HAL::Detail::NE_TSS kKernelTSS{};
+
+  if (!kHandoverHeader->f_StackTop) {
+    ke_stop(RUNTIME_CHECK_BOOTSTRAP, "No ring 0 stack in handover.");
+  }
 
   kKernelTSS.fRsp0 = (UInt64) kHandoverHeader->f_StackTop;
   kKernelTSS.fIopb = sizeof(HAL::Detail::NE_TSS);
@@ -135,6 +139,12 @@ EXTERN_C Ne::Kernel::Int32 hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* ha
 
 EXTERN_C BOOL rtl_init_nic_rtl8139();
 
+/// @brief Liveness probe, returns the handover magic to its caller.
+STATIC Ne::Kernel::VoidPtr ke_ping(Ne::Kernel::VoidPtr arg) {
+  NE_UNUSED(arg);
+  return (Ne::Kernel::VoidPtr) kHandoverMagic;
+}
+
 EXTERN_C Ne::Kernel::Void hal_real_init(Ne::Kernel::Void) {
   HAL::mp_init_cores(kHandoverHeader->f_HardwareTables.f_VendorPtr);
 
@@ -143,6 +153,10 @@ EXTERN_C Ne::Kernel::Void hal_real_init(Ne::Kernel::Void) {
 
   HAL::IDTLoader idt_loader;
   idt_loader.Load(idt_reg);
+
+  user_init_globals(kHandoverHeader->f_RecoverMode);
+
+  ke_install_syscall("ke_ping", ke_ping);
 
 #ifdef __FSKIT_INCLUDES_OPENHEFS__
   OpenHeFS::fs_init_openhefs();
@@ -156,12 +170,18 @@ EXTERN_C Ne::Kernel::Void hal_real_init(Ne::Kernel::Void) {
 
   UserProcessScheduler::The().SwitchTeam(kRTUserTeam);
 
-  PEFLoader ldr("/system/basesvc.exe");
+  if (kHandoverHeader->f_SCIImage && kHandoverHeader->f_SCIImageSz) {
+    PE32Loader ldr(kHandoverHeader->f_SCIImage, kHandoverHeader->f_SCIImageSz);
 
-  if (ldr.IsLoaded()) {
-    rtl_create_user_process(ldr, UserProcess::ExecutableKind::kExecutableKind);
+    if (ldr.IsLoaded() &&
+        rtl_create_user_process(ldr, UserProcess::ExecutableKind::kExecutableKind) !=
+            kCPSInvalidPID) {
+      (Void)(kout << "hal_real_init: Spawned the launch host.\r");
+    } else {
+      (Void)(kout << "hal_real_init: warning: Launch host did not spawn.\r");
+    }
   } else {
-    ke_stop(RUNTIME_CHECK_BAD_BEHAVIOR, "Invalid Launch Host Process.");
+    (Void)(kout << "hal_real_init: warning: No launch host in handover.\r");
   }
 
   UserProcessScheduler::The().SwitchTeam(kMidUserTeam);

--- a/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
+++ b/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
@@ -33,7 +33,8 @@ EXTERN_C Ne::Kernel::Int32 hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* ha
 
   HAL::rt_sti();
 
-  ::fw_init_efi(static_cast<EfiSystemTable*>(handover_hdr->f_FirmwareCustomTables[Ne::Kernel::HEL::kHandoverTableST]));
+  ::fw_init_efi(static_cast<EfiSystemTable*>(
+      handover_hdr->f_FirmwareCustomTables[Ne::Kernel::HEL::kHandoverTableST]));
 
   Boot::ExitBootServices(handover_hdr->f_HardwareTables.f_ImageKey,
                          handover_hdr->f_HardwareTables.f_ImageHandle);
@@ -53,14 +54,34 @@ EXTERN_C Ne::Kernel::Int32 hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* ha
   /*     INITIALIZE BIT MAP.              */
   /************************************** */
 
-  auto usable_sz = kHandoverHeader->f_BitMapSize / 2;
+  auto region_base = reinterpret_cast<UIntPtr>(kHandoverHeader->f_BitMapStart);
+  auto region_sz   = kHandoverHeader->f_BitMapSize;
+
+  /// @note images map at kPefBaseOrigin over the identity map, shadowing whatever
+  /// phys lives there. Keep the heap and the frames clear of that window.
+  constexpr UIntPtr kImgWinStart = kPefBaseOrigin;
+  constexpr UIntPtr kImgWinEnd   = kPefBaseOrigin + kPefMaxImageSz;
+
+  if (region_base < kImgWinEnd && region_base + region_sz > kImgWinStart) {
+    auto below = region_base < kImgWinStart ? kImgWinStart - region_base : (UIntPtr) 0UL;
+    auto above =
+        region_base + region_sz > kImgWinEnd ? region_base + region_sz - kImgWinEnd : (UIntPtr) 0UL;
+
+    if (below >= above) {
+      region_sz = below;
+    } else {
+      region_base = kImgWinEnd;
+      region_sz   = above;
+    }
+  }
+
+  auto usable_sz = region_sz / 2;
 
   kBitMapCursor     = 0UL;
   kKernelBitMpSize  = usable_sz;
-  kKernelBitMpStart = kHandoverHeader->f_BitMapStart;
+  kKernelBitMpStart = reinterpret_cast<VoidPtr>(region_base);
 
-  HAL::pmm_init(reinterpret_cast<UIntPtr>(kHandoverHeader->f_BitMapStart) + usable_sz,
-                kHandoverHeader->f_BitMapSize - usable_sz);
+  HAL::pmm_init(region_base + usable_sz, region_sz - usable_sz);
 
   /************************************** */
   /*     ADOPT OUR OWN PAGE TABLES.       */
@@ -122,8 +143,8 @@ EXTERN_C Ne::Kernel::Int32 hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* ha
        .fAccessByte = 0x92,
        .fFlags      = 0xCF,
        .fBaseHigh   = 0},  // Ne::Kernel data
-      {},                // TSS data low
-      {},                // TSS data high
+      {},                  // TSS data low
+      {},                  // TSS data high
       {.fLimitLow   = 0x0,
        .fBaseLow    = 0,
        .fBaseMid    = 0,

--- a/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
+++ b/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
@@ -187,7 +187,8 @@ EXTERN_C Ne::Kernel::Void hal_real_init(Ne::Kernel::Void) {
     (Void)(kout << "hal_real_init: warning: No launch host in handover.\r");
   }
 
-  UserProcessScheduler::The().SwitchTeam(kMidUserTeam);
+  /// @note SwitchTeam overwrites the whole team, switching again here would
+  /// discard the process we just spawned.
 
 #ifdef __HALKIT_INCLUDES_BNID__
   rtl_init_nic_rtl8139();

--- a/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
+++ b/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
@@ -10,6 +10,7 @@
 #include <KernelKit/CodeMgr.h>
 #include <KernelKit/HardwareThreadScheduler.h>
 #include <KernelKit/PEFCodeMgr.h>
+#include <KernelKit/PhysicalMemory.h>
 #include <KernelKit/ProcessScheduler.h>
 #include <KernelKit/Timer.h>
 #include <NetworkKit/IPC.h>
@@ -52,10 +53,14 @@ EXTERN_C Ne::Kernel::Int32 hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* ha
   /*     INITIALIZE BIT MAP.              */
   /************************************** */
 
-  kBitMapCursor    = 0UL;
-  kKernelBitMpSize = kHandoverHeader->f_BitMapSize;
-  kKernelBitMpStart =
-      reinterpret_cast<VoidPtr>(reinterpret_cast<UIntPtr>(kHandoverHeader->f_BitMapStart));
+  auto usable_sz = kHandoverHeader->f_BitMapSize / 2;
+
+  kBitMapCursor     = 0UL;
+  kKernelBitMpSize  = usable_sz;
+  kKernelBitMpStart = kHandoverHeader->f_BitMapStart;
+
+  HAL::pmm_init(reinterpret_cast<UIntPtr>(kHandoverHeader->f_BitMapStart) + usable_sz,
+                kHandoverHeader->f_BitMapSize - usable_sz);
 
   /************************************** */
   /*     INITIALIZE GDT AND SEGMENTS. */
@@ -142,6 +147,41 @@ EXTERN_C Ne::Kernel::Int32 hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* ha
 
 EXTERN_C BOOL rtl_init_nic_rtl8139();
 
+#ifdef __DEBUG__
+/// @brief Check the frame allocator's invariants on real memory.
+STATIC Ne::Kernel::Void pmm_self_test(Ne::Kernel::Void) {
+  using namespace Ne::Kernel;
+
+  auto a = HAL::pmm_alloc_frame();
+  auto b = HAL::pmm_alloc_frame();
+
+  if (!a || !b) {
+    (Void)(kout << "pmm: FAIL out of memory\r");
+    return;
+  }
+
+  if ((a & (kPageSize - 1)) || (b & (kPageSize - 1))) (Void)(kout << "pmm: FAIL alignment\r");
+  if (a == b) (Void)(kout << "pmm: FAIL duplicate frame\r");
+
+  for (SizeT i = 0UL; i < kPageSize; ++i) {
+    if (reinterpret_cast<UInt8*>(a)[i] != 0) {
+      (Void)(kout << "pmm: FAIL frame not zeroed\r");
+      break;
+    }
+  }
+
+  rt_set_memory(reinterpret_cast<VoidPtr>(b), 0xAB, kPageSize);
+  HAL::pmm_free_frame(b);
+
+  auto c = HAL::pmm_alloc_frame();
+
+  if (c != b) (Void)(kout << "pmm: FAIL free list did not reuse\r");
+  if (c && reinterpret_cast<UInt8*>(c)[8] != 0) (Void)(kout << "pmm: FAIL reuse not zeroed\r");
+
+  (Void)(kout << "pmm: self test done, free " << number(HAL::pmm_free_frames()) << kendl);
+}
+#endif  // __DEBUG__
+
 /// @brief Liveness probe, returns the handover magic to its caller.
 STATIC Ne::Kernel::VoidPtr ke_ping(Ne::Kernel::VoidPtr arg) {
   NE_UNUSED(arg);
@@ -156,6 +196,10 @@ EXTERN_C Ne::Kernel::Void hal_real_init(Ne::Kernel::Void) {
 
   HAL::IDTLoader idt_loader;
   idt_loader.Load(idt_reg);
+
+#ifdef __DEBUG__
+  pmm_self_test();
+#endif  // __DEBUG__
 
   user_init_globals(kHandoverHeader->f_RecoverMode);
 

--- a/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
+++ b/private/minkernel/HALKit/AMD64/HalKernelMain.cpp
@@ -63,6 +63,28 @@ EXTERN_C Ne::Kernel::Int32 hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* ha
                 kHandoverHeader->f_BitMapSize - usable_sz);
 
   /************************************** */
+  /*     ADOPT OUR OWN PAGE TABLES.       */
+  /************************************** */
+
+  constexpr UIntPtr kMinMapLimit = 0x100000000UL;
+  constexpr UIntPtr kGiBMask     = 0x3FFFFFFFUL;
+
+  auto ram_end =
+      reinterpret_cast<UIntPtr>(kHandoverHeader->f_BitMapStart) + kHandoverHeader->f_BitMapSize;
+
+  auto map_limit = ram_end > kMinMapLimit ? ((ram_end + kGiBMask) & ~kGiBMask) : kMinMapLimit;
+
+  auto kernel_pml4 = HAL::mm_init_kernel_tables(map_limit);
+
+  if (!kernel_pml4) {
+    ke_stop(RUNTIME_CHECK_BOOTSTRAP, "Can't build the kernel page tables.");
+  }
+
+  kKernelVM = reinterpret_cast<VoidPtr>(kernel_pml4);
+
+  hal_write_cr3(kKernelVM);
+
+  /************************************** */
   /*     INITIALIZE GDT AND SEGMENTS. */
   /************************************** */
 

--- a/private/minkernel/HALKit/AMD64/HalPagingMgr.cpp
+++ b/private/minkernel/HALKit/AMD64/HalPagingMgr.cpp
@@ -234,6 +234,10 @@ EXTERN_C Int32 mm_map_page_in(UIntPtr root, VoidPtr virtual_address, VoidPtr phy
                               UInt32 flags) {
   if (physical_address == 0) return kErrorInvalidData;
 
+  /// @note the PTE only holds bits 12..51, an unaligned frame would silently map
+  /// the page containing it and shift the whole view.
+  if ((UIntPtr) physical_address & (kPageSize - 1)) return kErrorInvalidData;
+
   auto slot = mm_walk_page(root, (UIntPtr) virtual_address, Yes);
 
   if (!slot) return kErrorInvalidData;
@@ -266,5 +270,24 @@ EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UI
   NE_UNUSED(level);
 
   return mm_map_page_in((UIntPtr) hal_read_cr3(), virtual_address, physical_address, flags);
+}
+
+/***********************************************************************************/
+/// @brief Unmaps a page, returns the frame it pointed at, 0 when there was none.
+/***********************************************************************************/
+EXTERN_C UIntPtr mm_unmap_page(VoidPtr virtual_address) {
+  auto slot = mm_walk_page((UIntPtr) hal_read_cr3(), (UIntPtr) virtual_address, No);
+
+  if (!slot || !(*slot & 1)) return 0UL;
+
+  constexpr UInt64 kAddrMask = 0x000FFFFFFFFFF000ULL;
+
+  auto frame = *slot & kAddrMask;
+
+  *slot = 0UL;
+
+  hal_invl_tlb(virtual_address);
+
+  return frame;
 }
 }  // namespace Ne::Kernel::HAL

--- a/private/minkernel/HALKit/AMD64/HalPagingMgr.cpp
+++ b/private/minkernel/HALKit/AMD64/HalPagingMgr.cpp
@@ -119,26 +119,36 @@ EXTERN_C UIntPtr mm_get_page_addr(VoidPtr virt) {
 
   if (!(pdpte & 1)) return 0;
 
+  constexpr UInt64 kPageSizeBit = 0x80;
+  constexpr UInt64 kAddrMask    = 0x000FFFFFFFFFF000ULL;
+
+  // A 1 GiB leaf stops the walk here.
+  if (pdpte & kPageSizeBit) {
+    constexpr UInt64 kGiBOffset = (1ULL << 30) - 1;
+
+    return (pdpte & kAddrMask & ~kGiBOffset) | (kVMAddr & kGiBOffset);
+  }
+
   // Level 2
   auto   pd  = reinterpret_cast<UInt64*>(pdpte & ~kPageOffsetMask);
   UInt64 pde = pd[(kVMAddr >> 21) & kMask9Bits];
 
   if (!(pde & 1)) return 0;
 
-  // 1 GiB page support
-  if (pde & (1 << 7)) {
-    return (pde & ~((1ULL << 30) - 1)) | (kVMAddr & ((1ULL << 30) - 1));
+  // A 2 MiB leaf, the identity map is built out of these.
+  if (pde & kPageSizeBit) {
+    constexpr UInt64 kLargeOffset = (1ULL << 21) - 1;
+
+    return (pde & kAddrMask & ~kLargeOffset) | (kVMAddr & kLargeOffset);
   }
 
   // Level 1
-  auto         pt  = reinterpret_cast<UInt64*>(pde & ~kPageOffsetMask);
-  Detail::PTE* pte = (Detail::PTE*) pt[(kVMAddr >> 12) & kMask9Bits];
+  auto   pt  = reinterpret_cast<UInt64*>(pde & ~kPageOffsetMask);
+  UInt64 pte = pt[(kVMAddr >> 12) & kMask9Bits];
 
-  if (!pte->Present) return 0;
+  if (!(pte & 1)) return 0;
 
-  mmi_page_status((Detail::PTE*) pte);
-
-  return (pte->PhysicalAddress << 12) | (kVMAddr & 0xFFF);
+  return (pte & kAddrMask) | (kVMAddr & kPageOffsetMask);
 }
 
 /***********************************************************************************/
@@ -160,58 +170,77 @@ EXTERN_C Int32 mm_memory_fence(VoidPtr virtual_address) {
 /// @param flags the flags to put on the page.
 /// @return Status code of page manipulation process.
 /***********************************************************************************/
-EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UInt32 flags,
-                           UInt32 level) {
+EXTERN_C UInt64* mm_walk_page(UIntPtr root, UIntPtr virtual_address, Bool alloc) {
+  constexpr UInt64 kMask9       = 0x1FF;
+  constexpr UInt64 kPageMask    = 0xFFF;
+  constexpr UInt64 kPageSizeBit = 0x80;
+  constexpr UInt64 kEntries     = 512;
+
+  /// @note privileges are ANDed down the walk, so every table on the way has to be
+  /// permissive and the leaf carries the real policy.
+  constexpr UInt64 kTablePerm = 0x7;  // present + writable + user
+
+  if (!root) return nullptr;
+
+  auto table = reinterpret_cast<UInt64*>(root & ~kPageMask);
+
+  /// PML4 -> PDPT -> PD, splitting anything mapped as a large page on the way down.
+  for (Int32 shift = 39; shift > 12; shift -= 9) {
+    auto  idx   = (virtual_address >> shift) & kMask9;
+    auto& entry = table[idx];
+
+    if (!(entry & 1)) {
+      if (!alloc) return nullptr;
+
+      auto frame = pmm_alloc_frame();
+
+      if (!frame) return nullptr;
+
+      entry = frame | kTablePerm;
+    } else if (entry & kPageSizeBit) {
+      if (!alloc) return nullptr;
+
+      auto frame = pmm_alloc_frame();
+
+      if (!frame) return nullptr;
+
+      auto step = 1ULL << shift;
+      auto base = entry & ~(step - 1);
+
+      /// @note carry the leaf's own attributes, never PS itself nor its PAT bit.
+      auto perm = (entry & 0x1F) | (entry & 0x100) | (entry & (1ULL << 63));
+
+      auto split = reinterpret_cast<UInt64*>(frame);
+
+      for (UInt64 i = 0UL; i < kEntries; ++i) {
+        split[i] = (base + (i * (step >> 9))) | perm | ((shift > 21) ? kPageSizeBit : 0);
+      }
+
+      entry = frame | kTablePerm;
+    } else {
+      entry |= kTablePerm;
+    }
+
+    table = reinterpret_cast<UInt64*>(entry & ~kPageMask);
+  }
+
+  return &table[(virtual_address >> 12) & kMask9];
+}
+
+/***********************************************************************************/
+/// @brief Maps a page into a specific address space.
+/***********************************************************************************/
+EXTERN_C Int32 mm_map_page_in(UIntPtr root, VoidPtr virtual_address, VoidPtr physical_address,
+                              UInt32 flags) {
   if (physical_address == 0) return kErrorInvalidData;
 
-  NE_UNUSED(level);  /// @todo support PML4, and PDPT levels.
+  auto slot = mm_walk_page(root, (UIntPtr) virtual_address, Yes);
 
-  const UInt64     kVMAddr   = (UInt64) virtual_address;
-  constexpr UInt64 kMask9    = 0x1FF;
-  constexpr UInt64 kPageMask = 0xFFF;
+  if (!slot) return kErrorInvalidData;
 
-  UInt64 cr3 = (UIntPtr) hal_read_cr3() & ~kPageMask;
+  Detail::PTE* pte = reinterpret_cast<Detail::PTE*>(slot);
 
-  auto   pml4  = reinterpret_cast<UInt64*>(cr3);
-  UInt64 pml4e = pml4[(kVMAddr >> 39) & kMask9];
-
-  if (!(pml4e & 1)) return kErrorInvalidData;
-
-  UInt64* pdpt  = reinterpret_cast<UInt64*>(pml4e & ~kPageMask);
-  UInt64  pdpte = pdpt[(kVMAddr >> 30) & kMask9];
-
-  if (!(pdpte & 1)) return kErrorInvalidData;
-
-  constexpr UInt64 kPageSizeBit = 0x80;
-
-  if (pdpte & kPageSizeBit) return kErrorInvalidData;
-
-  UInt64* pd  = reinterpret_cast<UInt64*>(pdpte & ~kPageMask);
-  UInt64  pde = pd[(kVMAddr >> 21) & kMask9];
-
-  if (!(pde & 1)) return kErrorInvalidData;
-
-  if (pde & kPageSizeBit) return kErrorInvalidData;
-
-  UInt64* pt = reinterpret_cast<UInt64*>(pde & ~kPageMask);
-
-  if (flags & kMMFlagsUser) {
-    constexpr UInt64 kUserBit = 0x4;
-
-    pml4[(kVMAddr >> 39) & kMask9] |= kUserBit;
-    pdpt[(kVMAddr >> 30) & kMask9] |= kUserBit;
-    pd[(kVMAddr >> 21) & kMask9] |= kUserBit;
-  }
-
-  if (flags & kMMFlagsWr) {
-    constexpr UInt64 kWriteBit = 0x2;
-
-    pml4[(kVMAddr >> 39) & kMask9] |= kWriteBit;
-    pdpt[(kVMAddr >> 30) & kMask9] |= kWriteBit;
-    pd[(kVMAddr >> 21) & kMask9] |= kWriteBit;
-  }
-
-  Detail::PTE* pte = reinterpret_cast<Detail::PTE*>(&pt[(kVMAddr >> 12) & kMask9]);
+  *slot = 0UL;
 
   pte->Present = !!(flags & kMMFlagsPresent);
   pte->Wr      = !!(flags & kMMFlagsWr);
@@ -224,10 +253,18 @@ EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UI
 
   hal_invl_tlb(virtual_address);
 
-  mm_memory_fence(virtual_address);
-
   mmi_page_status(pte);
 
   return kErrorSuccess;
+}
+
+/***********************************************************************************/
+/// @brief Maps a page into the address space we are running on.
+/***********************************************************************************/
+EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UInt32 flags,
+                           UInt32 level) {
+  NE_UNUSED(level);
+
+  return mm_map_page_in((UIntPtr) hal_read_cr3(), virtual_address, physical_address, flags);
 }
 }  // namespace Ne::Kernel::HAL

--- a/private/minkernel/HALKit/AMD64/HalPagingMgr.cpp
+++ b/private/minkernel/HALKit/AMD64/HalPagingMgr.cpp
@@ -5,6 +5,8 @@
 
 #include <HALKit/AMD64/Paging.h>
 #include <HALKit/AMD64/Processor.h>
+#include <KernelKit/DebugOutput.h>
+#include <KernelKit/PhysicalMemory.h>
 
 namespace Ne::Kernel::HAL {
 namespace Detail {
@@ -26,6 +28,52 @@ namespace Detail {
     UInt64 Nx : 1;                // No Execute, bit 63
   };
 }  // namespace Detail
+
+/***********************************************************************************/
+/// @brief Build page tables of our own and run on them.
+/// @param limit highest physical address that has to be reachable.
+/// @return the new PML4's physical address, 0 on failure.
+/***********************************************************************************/
+EXTERN_C UIntPtr mm_init_kernel_tables(UIntPtr limit) {
+  constexpr UIntPtr kEntries   = 512;
+  constexpr UIntPtr kLargePage = 0x200000;    // 2 MiB
+  constexpr UIntPtr kGiB       = 0x40000000;  // one PDPT entry's reach
+  constexpr UIntPtr kTablePerm = 0x3;         // present + writable
+  constexpr UIntPtr kLeafPerm  = 0x83;        // present + writable + PS
+
+  auto pml4_pa = pmm_alloc_frame();
+
+  if (!pml4_pa) return 0UL;
+
+  auto pml4 = reinterpret_cast<UInt64*>(pml4_pa);
+
+  for (UIntPtr base = 0UL; base < limit; base += kGiB) {
+    auto pml4_idx = (base >> 39) & (kEntries - 1);
+
+    if (!(pml4[pml4_idx] & 1)) {
+      auto pdpt_pa = pmm_alloc_frame();
+
+      if (!pdpt_pa) return 0UL;
+
+      pml4[pml4_idx] = pdpt_pa | kTablePerm;
+    }
+
+    auto pdpt  = reinterpret_cast<UInt64*>(pml4[pml4_idx] & ~(kPageSize - 1));
+    auto pd_pa = pmm_alloc_frame();
+
+    if (!pd_pa) return 0UL;
+
+    pdpt[(base >> 30) & (kEntries - 1)] = pd_pa | kTablePerm;
+
+    auto pd = reinterpret_cast<UInt64*>(pd_pa);
+
+    for (UIntPtr i = 0UL; i < kEntries; ++i) {
+      pd[i] = (base + (i * kLargePage)) | kLeafPerm;
+    }
+  }
+
+  return pml4_pa;
+}
 
 /***********************************************************************************/
 /// \brief Retrieve the page status of a PTE.
@@ -147,12 +195,6 @@ EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UI
 
   UInt64* pt = reinterpret_cast<UInt64*>(pde & ~kPageMask);
 
-  constexpr UInt64 kCr0WriteProtect = 0x10000;
-
-  auto cr0 = (UInt64) hal_read_cr0();
-
-  if (cr0 & kCr0WriteProtect) hal_write_cr0((VoidPtr) (cr0 & ~kCr0WriteProtect));
-
   if (flags & kMMFlagsUser) {
     constexpr UInt64 kUserBit = 0x4;
 
@@ -179,8 +221,6 @@ EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UI
   pte->Pwt     = !!(flags & kMMFlagsPwt);
 
   pte->PhysicalAddress = ((UIntPtr) (physical_address)) >> 12;
-
-  if (cr0 & kCr0WriteProtect) hal_write_cr0((VoidPtr) cr0);
 
   hal_invl_tlb(virtual_address);
 

--- a/private/minkernel/HALKit/AMD64/HalPagingMgr.cpp
+++ b/private/minkernel/HALKit/AMD64/HalPagingMgr.cpp
@@ -140,8 +140,31 @@ EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UI
 
   if (!(pde & 1)) return kErrorInvalidData;
 
-  UInt64*      pt  = reinterpret_cast<UInt64*>(pde & ~kPageMask);
-  Detail::PTE* pte = (Detail::PTE*) pt[(kVMAddr >> 12) & kMask9];
+  UInt64* pt = reinterpret_cast<UInt64*>(pde & ~kPageMask);
+
+  constexpr UInt64 kCr0WriteProtect = 0x10000;
+
+  auto cr0 = (UInt64) hal_read_cr0();
+
+  if (cr0 & kCr0WriteProtect) hal_write_cr0((VoidPtr) (cr0 & ~kCr0WriteProtect));
+
+  if (flags & kMMFlagsUser) {
+    constexpr UInt64 kUserBit = 0x4;
+
+    pml4[(kVMAddr >> 39) & kMask9] |= kUserBit;
+    pdpt[(kVMAddr >> 30) & kMask9] |= kUserBit;
+    pd[(kVMAddr >> 21) & kMask9] |= kUserBit;
+  }
+
+  if (flags & kMMFlagsWr) {
+    constexpr UInt64 kWriteBit = 0x2;
+
+    pml4[(kVMAddr >> 39) & kMask9] |= kWriteBit;
+    pdpt[(kVMAddr >> 30) & kMask9] |= kWriteBit;
+    pd[(kVMAddr >> 21) & kMask9] |= kWriteBit;
+  }
+
+  Detail::PTE* pte = reinterpret_cast<Detail::PTE*>(&pt[(kVMAddr >> 12) & kMask9]);
 
   pte->Present = !!(flags & kMMFlagsPresent);
   pte->Wr      = !!(flags & kMMFlagsWr);
@@ -151,6 +174,8 @@ EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UI
   pte->Pwt     = !!(flags & kMMFlagsPwt);
 
   pte->PhysicalAddress = ((UIntPtr) (physical_address)) >> 12;
+
+  if (cr0 & kCr0WriteProtect) hal_write_cr0((VoidPtr) cr0);
 
   hal_invl_tlb(virtual_address);
 

--- a/private/minkernel/HALKit/AMD64/HalPagingMgr.cpp
+++ b/private/minkernel/HALKit/AMD64/HalPagingMgr.cpp
@@ -23,8 +23,7 @@ namespace Detail {
     UInt64 PhysicalAddress : 40;  // Physical page frame address (bits 12–51)
     UInt64 Ignored2 : 7;          // More software bits / reserved
     UInt64 ProtectionKey : 4;     // Optional (if PKU enabled)
-    UInt64 Reserved : 1;          // Usually reserved
-    UInt64 Nx : 1;                // No Execute
+    UInt64 Nx : 1;                // No Execute, bit 63
   };
 }  // namespace Detail
 
@@ -135,10 +134,16 @@ EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UI
 
   if (!(pdpte & 1)) return kErrorInvalidData;
 
+  constexpr UInt64 kPageSizeBit = 0x80;
+
+  if (pdpte & kPageSizeBit) return kErrorInvalidData;
+
   UInt64* pd  = reinterpret_cast<UInt64*>(pdpte & ~kPageMask);
   UInt64  pde = pd[(kVMAddr >> 21) & kMask9];
 
   if (!(pde & 1)) return kErrorInvalidData;
+
+  if (pde & kPageSizeBit) return kErrorInvalidData;
 
   UInt64* pt = reinterpret_cast<UInt64*>(pde & ~kPageMask);
 

--- a/private/minkernel/HALKit/AMD64/Paging.h
+++ b/private/minkernel/HALKit/AMD64/Paging.h
@@ -81,8 +81,7 @@ struct PTE {
   UInt64 PhysicalAddress : 40;  // Physical page frame address (bits 12–51)
   UInt64 Ignored2 : 7;          // More software bits / reserved
   UInt64 ProtectionKey : 4;     // Optional (if PKU enabled)
-  UInt64 Reserved : 1;          // Usually reserved
-  UInt64 Nx : 1;                // No Execute
+  UInt64 Nx : 1;                // No Execute, bit 63
 };
 
 struct PDE {

--- a/private/minkernel/HALKit/AMD64/Processor.h
+++ b/private/minkernel/HALKit/AMD64/Processor.h
@@ -36,6 +36,9 @@
 /// @brief interrupt for system call.
 #define kKernelInterruptId (0x32)
 
+/// @brief interrupt for kernel call.
+#define kKernelCallId (0x33)
+
 #define IsActiveLow(FLG) (FLG & 2)
 #define IsLevelTriggered(FLG) (FLG & 8)
 

--- a/private/minkernel/HALKit/AMD64/Processor.h
+++ b/private/minkernel/HALKit/AMD64/Processor.h
@@ -255,6 +255,14 @@ EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UI
 /// @return the new PML4's physical address, 0 on failure.
 EXTERN_C UIntPtr mm_init_kernel_tables(UIntPtr limit);
 
+/// @brief Walk to the leaf slot for an address, allocating and splitting on the way.
+/// @return the entry's address, or nullptr.
+EXTERN_C UInt64* mm_walk_page(UIntPtr root, UIntPtr virtual_address, Bool alloc);
+
+/// @brief Map a page into a given address space.
+EXTERN_C Int32 mm_map_page_in(UIntPtr root, VoidPtr virtual_address, VoidPtr physical_address,
+                              UInt32 flags);
+
 EXTERN_C UInt8  rt_in8(UInt16 port);
 EXTERN_C UInt16 rt_in16(UInt16 port);
 EXTERN_C UInt32 rt_in32(UInt16 port);

--- a/private/minkernel/HALKit/AMD64/Processor.h
+++ b/private/minkernel/HALKit/AMD64/Processor.h
@@ -263,6 +263,9 @@ EXTERN_C UInt64* mm_walk_page(UIntPtr root, UIntPtr virtual_address, Bool alloc)
 EXTERN_C Int32 mm_map_page_in(UIntPtr root, VoidPtr virtual_address, VoidPtr physical_address,
                               UInt32 flags);
 
+/// @brief Unmap a page, returns the frame it held.
+EXTERN_C UIntPtr mm_unmap_page(VoidPtr virtual_address);
+
 EXTERN_C UInt8  rt_in8(UInt16 port);
 EXTERN_C UInt16 rt_in16(UInt16 port);
 EXTERN_C UInt32 rt_in32(UInt16 port);

--- a/private/minkernel/HALKit/AMD64/Processor.h
+++ b/private/minkernel/HALKit/AMD64/Processor.h
@@ -39,6 +39,11 @@
 /// @brief interrupt for kernel call.
 #define kKernelCallId (0x33)
 
+/// @brief faults routed to the TSS interrupt stack.
+#define kDoubleFaultId (0x08)
+#define kPageFaultId (0x0E)
+#define kFaultStackId (1)
+
 #define IsActiveLow(FLG) (FLG & 2)
 #define IsLevelTriggered(FLG) (FLG & 8)
 
@@ -190,7 +195,8 @@ Void hal_set_msr(UInt32 msr, UInt32 lo, UInt32 hi);
 /// @brief Processor specific namespace.
 namespace Detail {
   /* @brief TSS struct. */
-  struct NE_TSS final {
+  /// @note the layout is fixed by the CPU, rsp0 sits at offset 4 and is unaligned.
+  struct PACKED NE_TSS final {
     UInt32 fReserved1;
     UInt64 fRsp0;
     UInt64 fRsp1;

--- a/private/minkernel/HALKit/AMD64/Processor.h
+++ b/private/minkernel/HALKit/AMD64/Processor.h
@@ -251,6 +251,10 @@ class LAPICDmaWrapper final {
 EXTERN_C Int32 mm_map_page(VoidPtr virtual_address, VoidPtr physical_address, UInt32 flags,
                            UInt32 level = 2);
 
+/// @brief Build page tables owned by the kernel, identity mapping up to limit.
+/// @return the new PML4's physical address, 0 on failure.
+EXTERN_C UIntPtr mm_init_kernel_tables(UIntPtr limit);
+
 EXTERN_C UInt8  rt_in8(UInt16 port);
 EXTERN_C UInt16 rt_in16(UInt16 port);
 EXTERN_C UInt32 rt_in32(UInt16 port);

--- a/private/minkernel/HALKit/ARM64/HalCoreInterruptHandler.cpp
+++ b/private/minkernel/HALKit/ARM64/HalCoreInterruptHandler.cpp
@@ -123,19 +123,19 @@ EXTERN_C void int_handle_ud(Ne::Kernel::UIntPtr rsp) {
 /// @brief Enter syscall from assembly (libSystem only)
 /// @param stack the stack pushed from assembly routine.
 /// @return nothing.
-EXTERN_C Ne::Kernel::Void hal_system_call_enter(Ne::Kernel::UIntPtr rcx_hash,
-                                            Ne::Kernel::UIntPtr rdx_syscall_arg) {
-  hal_int_send_eoi(50);
-
-  if (!Ne::Kernel::kCurrentUser) return;
+EXTERN_C Ne::Kernel::VoidPtr hal_system_call_enter(Ne::Kernel::UIntPtr rcx_hash,
+                                                   Ne::Kernel::UIntPtr rdx_syscall_arg) {
+  if (!Ne::Kernel::kCurrentUser) return nullptr;
 
   for (SizeT i = 0UL; i < kMaxDispatchCallCount; ++i) {
     if (kSysCalls[i].fHooked && rcx_hash == kSysCalls[i].fHash) {
-      if (kSysCalls[i].fProc) {
-        (kSysCalls[i].fProc)((Ne::Kernel::VoidPtr) rdx_syscall_arg);
-      }
+      if (!kSysCalls[i].fProc) break;
+
+      return (kSysCalls[i].fProc)((Ne::Kernel::VoidPtr) rdx_syscall_arg);
     }
   }
+
+  return nullptr;
 }
 
 /// @brief Enter Ne::Kernel call from assembly (libDDK only).

--- a/private/minkernel/HALKit/ARM64/HalKernelMain.cpp
+++ b/private/minkernel/HALKit/ARM64/HalKernelMain.cpp
@@ -27,12 +27,11 @@ EXTERN_C void hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* handover_hdr) {
   /*     INITIALIZE AND VALIDATE HEADER.              */
   /************************************************** */
 
-  kHandoverHeader = handover_hdr;
-
-  if (kHandoverHeader->f_Magic != kHandoverMagic &&
-      kHandoverHeader->f_Version != kHandoverVersion) {
+  if (handover_hdr->f_Magic != kHandoverMagic || handover_hdr->f_Version != kHandoverVersion) {
     return;
   }
+
+  kHandoverHeader = handover_hdr;
 
 #ifdef __NE_ARM64_EFI__
   ::fw_init_efi(static_cast<EfiSystemTable*>(handover_hdr->f_FirmwareCustomTables[Ne::Kernel::HEL::kHandoverTableST]));
@@ -55,6 +54,8 @@ EXTERN_C void hal_init_platform(Ne::Kernel::HEL::BootInfoHeader* handover_hdr) {
   /// @note do initialize the interrupts after it.
 
   Ne::Kernel::mp_init_cores();
+
+  Ne::Kernel::user_init_globals(kHandoverHeader->f_RecoverMode);
 
   while (YES);
 }

--- a/private/minkernel/KernelKit/CoreProcessScheduler.h
+++ b/private/minkernel/KernelKit/CoreProcessScheduler.h
@@ -227,6 +227,7 @@ struct ProcessImage final {
 
   ImagePtr fCode{};
   ImagePtr fBlob{};
+  SizeT    fBlobSz{};
 
  public:
   Bool HasCode() const { return this->fCode != nullptr; }
@@ -248,6 +249,8 @@ struct ProcessImage final {
 
     return ErrorOr<ImagePtr>{kErrorInvalidData};
   }
+
+  SizeT LeakBlobSz() const { return this->fBlobSz; }
 };
 
 }  // namespace Ne::Kernel

--- a/private/minkernel/KernelKit/FileMgr.h
+++ b/private/minkernel/KernelKit/FileMgr.h
@@ -506,7 +506,8 @@ inline FileStream<Encoding, Class>::FileStream(const Encoding* path, const Encod
 /// @brief destructor of the file stream.
 template <typename Encoding, typename Class>
 inline FileStream<Encoding, Class>::~FileStream() {
-  if (fFile) mm_free_ptr(fFile);
+  if (mm_is_valid_ptr(fFile)) mm_free_ptr(fFile);
+
   kout << "FileMgr: ~FileStream()\r";
 
   fFile = nullptr;

--- a/private/minkernel/KernelKit/IDylibObject.h
+++ b/private/minkernel/KernelKit/IDylibObject.h
@@ -22,6 +22,7 @@ class IDylibObject {
 
   struct DylibTraits final {
     VoidPtr ImageObject{nullptr};
+    SizeT   ImageSz{0UL};
     VoidPtr ImageEntrypointOffset{nullptr};
 
     VoidPtr Image() const { return ImageObject; }

--- a/private/minkernel/KernelKit/IPEFDylibObject.h
+++ b/private/minkernel/KernelKit/IPEFDylibObject.h
@@ -50,7 +50,7 @@ class IPEFDylibObject final NE_DYLIB_OBJECT {
     }
 
     if (!fLoader) {
-      fLoader = new PEFLoader(fMounted->ImageObject);
+      fLoader = new PEFLoader(fMounted->ImageObject, fMounted->ImageSz);
     }
   }
 

--- a/private/minkernel/KernelKit/PE.h
+++ b/private/minkernel/KernelKit/PE.h
@@ -18,6 +18,9 @@
 
 #define kNeKernelPESubsystem (0x11)
 
+/* Sanity cap for untrusted images. */
+#define kPeMaxImageSz (0x4000000U)
+
 typedef struct LDR_EXEC_HEADER final {
   Ne::Kernel::UInt32 Signature;
   Ne::Kernel::UInt16 Machine;

--- a/private/minkernel/KernelKit/PE32CodeMgr.h
+++ b/private/minkernel/KernelKit/PE32CodeMgr.h
@@ -34,7 +34,7 @@ class PE32Loader NE_EXEC_LOADER {
   explicit PE32Loader() = delete;
 
  public:
-  explicit PE32Loader(const VoidPtr blob);
+  explicit PE32Loader(const VoidPtr blob, const SizeT len);
   explicit PE32Loader(const Char* path);
   ~PE32Loader() override;
 
@@ -56,6 +56,10 @@ class PE32Loader NE_EXEC_LOADER {
   BOOL IsLoaded();
 
  private:
+  /// @brief Instantiate the image in memory, then map it. Idempotent.
+  ErrorOr<VoidPtr> LoadImage();
+
+ private:
 #ifdef __FSKIT_INCLUDES_NEFS__
   OwnPtr<FileStream<Char, NeFileSystemMgr>> fFile;
 #elif defined(__FSKIT_INCLUDES_OPENHEFS__)
@@ -66,6 +70,8 @@ class PE32Loader NE_EXEC_LOADER {
 
   Ref<KString> fPath;
   ErrorOrAny   fCachedBlob{};
+  SizeT        fCachedBlobSz{};
+  VoidPtr      fImage{};
   BOOL         fBad{};
 };
 

--- a/private/minkernel/KernelKit/PEF.h
+++ b/private/minkernel/KernelKit/PEF.h
@@ -31,6 +31,10 @@
 
 #define kPefBaseOrigin (0x40000000)
 
+/* Sanity caps for untrusted containers. */
+#define kPefMaxSections (64U)
+#define kPefMaxImageSz (0x4000000U)
+
 #define kPefStart "__ImageStart"
 #define kPefMainSymbol "_NeMain"
 

--- a/private/minkernel/KernelKit/PEFCodeMgr.h
+++ b/private/minkernel/KernelKit/PEFCodeMgr.h
@@ -32,7 +32,7 @@ class PEFLoader NE_EXEC_LOADER {
   explicit PEFLoader() = delete;
 
  public:
-  explicit PEFLoader(const VoidPtr blob);
+  explicit PEFLoader(const VoidPtr blob, const SizeT len);
   explicit PEFLoader(const Char* path);
   ~PEFLoader() override;
 
@@ -50,7 +50,8 @@ class PEFLoader NE_EXEC_LOADER {
   ErrorOr<VoidPtr> GetBlob() override;
 
  public:
-  bool IsLoaded();
+  bool  IsLoaded();
+  SizeT BlobSz() const { return fCachedBlobSz; }
 
  private:
 #ifdef __FSKIT_INCLUDES_NEFS__
@@ -63,8 +64,10 @@ class PEFLoader NE_EXEC_LOADER {
 
   Ref<KString> fPath;
   ErrorOrAny   fCachedBlob;
+  SizeT        fCachedBlobSz{};
   BOOL         fFatBinary{};
   BOOL         fBad{};
+  BOOL         fOwnsBlob{};
 };
 
 ProcessID rtl_create_user_process(PEFLoader& exec, const UserProcess::ExecutableKind& procKind);

--- a/private/minkernel/KernelKit/PhysicalMemory.h
+++ b/private/minkernel/KernelKit/PhysicalMemory.h
@@ -1,0 +1,28 @@
+#ifndef KERNELKIT_PHYSICALMEMORY_H
+#define KERNELKIT_PHYSICALMEMORY_H
+
+#include <NeKit/Config.h>
+#include <hint/CompilerHint.h>
+
+#ifdef __NE_AMD64__
+#include <HALKit/AMD64/Paging.h>
+#endif  // __NE_AMD64__
+
+namespace Ne::Kernel::HAL {
+/// @brief Hand a physical region to the frame allocator.
+Void pmm_init(UIntPtr base, SizeT sz);
+
+/// @brief Take one zeroed frame, 0 when out of memory.
+_Output UIntPtr pmm_alloc_frame(Void);
+
+/// @brief Give a frame back.
+Void pmm_free_frame(UIntPtr frame);
+
+/// @brief Frames still available.
+_Output SizeT pmm_free_frames(Void);
+
+/// @brief Frames handed out.
+_Output SizeT pmm_used_frames(Void);
+}  // namespace Ne::Kernel::HAL
+
+#endif /* ifndef KERNELKIT_PHYSICALMEMORY_H */

--- a/private/minkernel/KernelKit/User.h
+++ b/private/minkernel/KernelKit/User.h
@@ -25,6 +25,10 @@
 #define kGuestUser "NEKERNEL/GUEST/%s"
 #define kStdUser "NEKERNEL/STD/%s"
 
+///! Built-in users, bound by user_init_globals.
+#define kRootUserName u8"NEKERNEL/MGMT/root"
+#define kGuestUserName u8"NEKERNEL/GUEST/guest"
+
 #define kUsersDir "/users/"
 
 #define kMaxUserNameLen (256U)
@@ -75,6 +79,9 @@ class User final {
   /// @brief Is she a super user?
   Bool IsSuperUser();
 
+  /// @brief Is he a guest user?
+  Bool IsGuestUser();
+
   /// @brief Saves a password from the public key.
   Bool Save(const UserPublicKey password);
 
@@ -104,6 +111,10 @@ inline UserPtr kRootUser = nullptr;
 
 /// \brief Guest user pointer.
 inline UserPtr kGuest = nullptr;
+
+/// @brief Bind the built-in users.
+/// @param recovery make the guest user current instead of root.
+Void user_init_globals(const Bool recovery);
 
 }  // namespace Ne::Kernel
 

--- a/private/minkernel/KernelKit/UserProcessScheduler.h
+++ b/private/minkernel/KernelKit/UserProcessScheduler.h
@@ -237,11 +237,11 @@ class UserProcessScheduler final : public ISchedulable {
   bool     operator!();
 
  public:
-  Ref<UserProcessTeam> TheCurrentTeam();
+  UserProcessTeam&     TheCurrentTeam();
   BOOL                 SwitchTeam(UserProcessTeam& team);
 
  public:
-  ProcessID Spawn(const Char* name, VoidPtr code, VoidPtr image);
+  ProcessID Spawn(const Char* name, VoidPtr code, VoidPtr image, SizeT image_sz = 0UL);
   Void      Remove(ProcessID process_id);
 
   Bool IsUser() override;

--- a/private/minkernel/KernelKit/UserProcessScheduler.h
+++ b/private/minkernel/KernelKit/UserProcessScheduler.h
@@ -237,8 +237,8 @@ class UserProcessScheduler final : public ISchedulable {
   bool     operator!();
 
  public:
-  UserProcessTeam&     TheCurrentTeam();
-  BOOL                 SwitchTeam(UserProcessTeam& team);
+  UserProcessTeam& TheCurrentTeam();
+  BOOL             SwitchTeam(UserProcessTeam& team);
 
  public:
   ProcessID Spawn(const Char* name, VoidPtr code, VoidPtr image, SizeT image_sz = 0UL);

--- a/private/minkernel/src/BitMapMgr.cpp
+++ b/private/minkernel/src/BitMapMgr.cpp
@@ -90,7 +90,11 @@ namespace HAL {
 
         STATIC SizeT biggest{0UL};
 
+        auto limit = reinterpret_cast<UIntPtr>(kKernelBitMpStart) + kKernelBitMpSize;
+
         while (YES) {
+          if ((reinterpret_cast<UIntPtr>(base) + size + pad) > limit) return nullptr;
+
           UIntPtr* ptr_bit_set = reinterpret_cast<UIntPtr*>(base);
 
           if (ptr_bit_set[kBitMapMagIdx] == kBitMapMagic &&
@@ -100,9 +104,6 @@ namespace HAL {
               ptr_bit_set[kBitMapUsedIdx] = Yes;
 
               this->GetBitMapStatus(ptr_bit_set);
-
-              UInt32 flags = this->MakeMMFlags(wr, user);
-              mm_map_page(ptr_bit_set, (VoidPtr) mm_get_page_addr(ptr_bit_set), flags);
 
               if (biggest < (size + pad)) biggest = size + pad;
               kBitMapCursor += size + pad;
@@ -116,8 +117,8 @@ namespace HAL {
 
             this->GetBitMapStatus(ptr_bit_set);
 
-            UInt32 flags = this->MakeMMFlags(wr, user);
-            mm_map_page(ptr_bit_set, (VoidPtr) mm_get_page_addr(ptr_bit_set), flags);
+            NE_UNUSED(wr);
+            NE_UNUSED(user);
 
             if (biggest < (size + pad)) biggest = (size + pad);
             kBitMapCursor += size + pad;

--- a/private/minkernel/src/BitMapMgr.cpp
+++ b/private/minkernel/src/BitMapMgr.cpp
@@ -54,10 +54,11 @@ namespace HAL {
 
         this->GetBitMapStatus(ptr_bit_set);
 
-        kBitMapCursor += ptr_bit_set[kBitMapSizeIdx];
+        if (kBitMapCursor >= ptr_bit_set[kBitMapSizeIdx])
+          kBitMapCursor -= ptr_bit_set[kBitMapSizeIdx];
 
-        ptr_bit_set[kBitMapMagIdx]  = 0UL;
-        ptr_bit_set[kBitMapSizeIdx] = 0UL;
+        /// @note magic and size have to survive, FindBitMap walks by them and
+        /// would otherwise reclaim this hole at the wrong size.
         ptr_bit_set[kBitMapUsedIdx] = No;
 
         return Yes;

--- a/private/minkernel/src/FS/OpenHeFS+FileMgr.cpp
+++ b/private/minkernel/src/FS/OpenHeFS+FileMgr.cpp
@@ -14,10 +14,53 @@
 
 namespace Ne::Kernel {
 
+namespace Detail {
+  /// @brief An open OpenHeFS file. The parser is name addressed, so we keep the
+  /// path split apart and carry the cursor the parser has no room for.
+  struct HEFS_NODE_DESC final {
+    Utf8Char fDir[kOpenHeFSFileNameLen];
+    Utf8Char fName[kOpenHeFSFileNameLen];
+    SizeT    fCursor;
+    UInt8    fKind;
+  };
+
+  /// @brief Split a path into its directory and its basename.
+  /// @return NO when either half does not fit.
+  STATIC Bool hefs_split_path(const Char* path, Utf8Char* dir, Utf8Char* name) {
+    if (!path || *path != '/') return NO;
+
+    auto len = rt_string_len(path, kOpenHeFSFileNameLen);
+
+    if (len < 2 || len >= kOpenHeFSFileNameLen) return NO;
+
+    auto cut = 0UL;
+
+    for (SizeT i = 0UL; i < len; ++i) {
+      if (path[i] == '/') cut = i;
+    }
+
+    auto name_len = len - cut - 1;
+
+    if (name_len < 1 || name_len >= kOpenHeFSFileNameLen) return NO;
+
+    auto dir_len = cut ? cut : 1;
+
+    for (SizeT i = 0UL; i < dir_len; ++i) dir[i] = path[i];
+    dir[dir_len] = 0;
+
+    for (SizeT i = 0UL; i < name_len; ++i) name[i] = path[cut + 1 + i];
+    name[name_len] = 0;
+
+    return YES;
+  }
+}  // namespace Detail
+
 /// @brief C++ constructor
 HeFileSystemMgr::HeFileSystemMgr() {
   mParser = new HeFileSystemParser();
   MUST_PASS(mParser);
+
+  io_construct_main_drive(mDriveTrait);
 
   kout << "OpenHeFS: Allocated HeFileSystemParser...\r";
 }
@@ -40,16 +83,18 @@ bool HeFileSystemMgr::Remove(_Input const Char* path) {
     return NO;
   }
 
-  auto len = oe_string_len<Char>(path);
+  Utf8Char dir[kOpenHeFSFileNameLen]  = {0};
+  Utf8Char name[kOpenHeFSFileNameLen] = {0};
 
-  if (len == 0) return NO;
-
-  Utf8Char* out = static_cast<Utf8Char*>(RTL_ALLOCA(sizeof(Utf8Char) * len));
+  if (!Detail::hefs_split_path(path, dir, name)) {
+    err_local_get() = kErrorInvalidData;
+    return NO;
+  }
 
   err_local_get() = kErrorSuccess;
 
-  bool ret = mParser->DeleteINode(&mDriveTrait, 0, nullptr, out, 0);
-  return ret;
+  return mParser->DeleteINode(&mDriveTrait, kOpenHeFSEncodingFlagsUTF8, dir, name,
+                              kOpenHeFSFileKindRegular);
 }
 
 /// @brief Creates a node with the specified.
@@ -61,26 +106,26 @@ NodePtr HeFileSystemMgr::Create(_Input const Char* path) {
     return nullptr;
   }
 
-  // TODO: It needs its own helper!
-  SizeT len = oe_string_len<Char>(path);
+  Utf8Char dir[kOpenHeFSFileNameLen]  = {0};
+  Utf8Char name[kOpenHeFSFileNameLen] = {0};
 
-  if (len == 0) return nullptr;
-
-  Utf8Char* out = static_cast<Utf8Char*>(RTL_ALLOCA(sizeof(Utf8Char) * len));
-
-  for (SizeT indx = 0UL; indx < len; ++indx) {
-    out[indx] = path[indx];
+  if (!Detail::hefs_split_path(path, dir, name)) {
+    err_local_get() = kErrorInvalidData;
+    return nullptr;
   }
 
   err_local_get() = kErrorSuccess;
 
-  if (auto node = mParser->CreateINode(&mDriveTrait, 0, nullptr, out, 0); node) return nullptr;
+  if (!mParser->CreateINode(&mDriveTrait, kOpenHeFSEncodingFlagsUTF8, dir, name,
+                            kOpenHeFSFileKindRegular)) {
+    kout << "OpenHeFS: ERROR: Check KPC.\r";
 
-  kout << "OpenHeFS: ERROR: Check KPC.\r";
+    err_local_get() = kErrorDiskIsFull;
 
-  err_local_get() = kErrorDiskIsFull;
+    return nullptr;
+  }
 
-  return nullptr;
+  return this->Open(path, "rb");
 }
 
 /// @brief Creates a node which is a directory.
@@ -92,24 +137,24 @@ NodePtr HeFileSystemMgr::CreateDirectory(const Char* path) {
     return nullptr;
   }
 
-  // TODO: It needs its own helper!
-  SizeT len = oe_string_len<Char>(path);
+  Utf8Char dir[kOpenHeFSFileNameLen] = {0};
 
-  if (len == 0) return nullptr;
+  auto len = rt_string_len(path, kOpenHeFSFileNameLen);
 
-  Utf8Char* out = static_cast<Utf8Char*>(RTL_ALLOCA(sizeof(Utf8Char) * len));
-
-  for (SizeT indx = 0UL; indx < len; ++indx) {
-    out[indx] = path[indx];
+  if (len < 1 || len >= kOpenHeFSFileNameLen) {
+    err_local_get() = kErrorInvalidData;
+    return nullptr;
   }
+
+  for (SizeT i = 0UL; i < len; ++i) dir[i] = path[i];
 
   err_local_get() = kErrorSuccess;
 
-  if (auto node = mParser->CreateINodeDirectory(&mDriveTrait, 0, out); node) return nullptr;
+  if (!mParser->CreateINodeDirectory(&mDriveTrait, kOpenHeFSEncodingFlagsUTF8, dir)) {
+    kout << "OpenHeFS: ERROR: Check KPC.\r";
 
-  kout << "OpenHeFS: ERROR: Check KPC.\r";
-
-  err_local_get() = kErrorDiskIsFull;
+    err_local_get() = kErrorDiskIsFull;
+  }
 
   return nullptr;
 }
@@ -123,27 +168,22 @@ NodePtr HeFileSystemMgr::CreateAlias(const Char* path) {
     return nullptr;
   }
 
-  // TODO: It needs its own helper!
-  SizeT len = oe_string_len<Char>(path);
+  Utf8Char dir[kOpenHeFSFileNameLen]  = {0};
+  Utf8Char name[kOpenHeFSFileNameLen] = {0};
 
-  if (len == 0) return nullptr;
-
-  Utf8Char* out = static_cast<Utf8Char*>(RTL_ALLOCA(sizeof(Utf8Char) * len));
-
-  for (SizeT indx = 0UL; indx < len; ++indx) {
-    out[indx] = path[indx];
+  if (!Detail::hefs_split_path(path, dir, name)) {
+    err_local_get() = kErrorInvalidData;
+    return nullptr;
   }
 
   err_local_get() = kErrorSuccess;
 
-  if (auto node =
-          mParser->CreateINode(&mDriveTrait, kOpenHeFSFileKindSymbolicLink, nullptr, out, 0);
-      node)
-    return nullptr;
+  if (!mParser->CreateINode(&mDriveTrait, kOpenHeFSEncodingFlagsUTF8, dir, name,
+                            kOpenHeFSFileKindSymbolicLink)) {
+    kout << "OpenHeFS: ERROR: Check KPC.\r";
 
-  kout << "OpenHeFS: ERROR: Check KPC.\r";
-
-  err_local_get() = kErrorDiskIsFull;
+    err_local_get() = kErrorDiskIsFull;
+  }
 
   return nullptr;
 }
@@ -199,15 +239,57 @@ _Output NodePtr HeFileSystemMgr::Open(_Input const Char* path, _Input const Char
     return nullptr;
   }
 
-  return nullptr;
+  auto desc = new Detail::HEFS_NODE_DESC();
+
+  if (!desc) {
+    err_local_get() = kErrorHeapOutOfMemory;
+    return nullptr;
+  }
+
+  if (!Detail::hefs_split_path(path, desc->fDir, desc->fName)) {
+    delete desc;
+
+    err_local_get() = kErrorInvalidData;
+
+    return nullptr;
+  }
+
+  desc->fKind   = kOpenHeFSFileKindRegular;
+  desc->fCursor = 0UL;
+
+  if (!mParser->INodeExists(&mDriveTrait, desc->fDir, desc->fName, desc->fKind)) {
+    delete desc;
+
+    err_local_get() = kErrorFileNotFound;
+
+    return nullptr;
+  }
+
+  err_local_get() = kErrorSuccess;
+
+  return rtl_node_cast(desc);
 }
 
 Void HeFileSystemMgr::Write(_Input NodePtr node, _Input VoidPtr data, _Input Int32 flags,
                             _Input SizeT size) {
-  NE_UNUSED(node);
   NE_UNUSED(flags);
-  NE_UNUSED(size);
-  NE_UNUSED(data);
+
+  if (!node || !data || !size) return;
+
+  auto desc = reinterpret_cast<Detail::HEFS_NODE_DESC*>(node);
+
+  if (size > kOpenHeFSBlockLen) {
+    err_local_get() = kErrorDiskIsFull;
+    return;
+  }
+
+  if (!mParser->INodeManip(&mDriveTrait, data, size, desc->fDir, desc->fName, desc->fKind, NO)) {
+    err_local_get() = kErrorFileNotFound;
+    return;
+  }
+
+  desc->fCursor   = size;
+  err_local_get() = kErrorSuccess;
 }
 
 _Output VoidPtr HeFileSystemMgr::Read(_Input NodePtr node, _Input Int32 flags, _Input SizeT size) {
@@ -215,7 +297,31 @@ _Output VoidPtr HeFileSystemMgr::Read(_Input NodePtr node, _Input Int32 flags, _
 
   if (!node || !size) return nullptr;
 
-  return nullptr;
+  auto desc = reinterpret_cast<Detail::HEFS_NODE_DESC*>(node);
+
+  if (size > kOpenHeFSBlockLen) size = kOpenHeFSBlockLen;
+
+  auto blob = mm_alloc_ptr(size, Yes, No);
+
+  if (!blob) {
+    err_local_get() = kErrorHeapOutOfMemory;
+    return nullptr;
+  }
+
+  rt_set_memory(blob, 0, size);
+
+  if (!mParser->INodeManip(&mDriveTrait, blob, size, desc->fDir, desc->fName, desc->fKind, YES)) {
+    mm_free_ptr(blob);
+
+    err_local_get() = kErrorFileNotFound;
+
+    return nullptr;
+  }
+
+  desc->fCursor   = size;
+  err_local_get() = kErrorSuccess;
+
+  return blob;
 }
 
 /// @note name is not used in OpenHeFS to mark data offsets. That's an NeFS-ism.
@@ -256,9 +362,16 @@ _Output VoidPtr HeFileSystemMgr::Read(_Input const Char* name, _Input NodePtr no
 }
 
 _Output Bool HeFileSystemMgr::Seek(NodePtr node, SizeT off) {
-  if (this->Tell(node) == kFileMgrNPos) return false;
-  kout << "The Method is not implemented in the Hybrid kernel.\r";
-  return off > 0;
+  if (!node) return NO;
+
+  if (off >= kOpenHeFSBlockLen) {
+    err_local_get() = kErrorInvalidData;
+    return NO;
+  }
+
+  reinterpret_cast<Detail::HEFS_NODE_DESC*>(node)->fCursor = off;
+
+  return YES;
 }
 
 /// @brief Tell current offset within catalog.
@@ -266,17 +379,17 @@ _Output Bool HeFileSystemMgr::Seek(NodePtr node, SizeT off) {
 /// @return kFileMgrNPos if invalid, else current offset.
 _Output SizeT HeFileSystemMgr::Tell(NodePtr node) {
   if (!node) return kFileMgrNPos;
-  SizeT pos = 0ULL;
-  kout << "The Method is not implemented in the Hybrid kernel.\r";
-  return pos;
+
+  return reinterpret_cast<Detail::HEFS_NODE_DESC*>(node)->fCursor;
 }
 
 /// @brief Rewinds the catalog
 /// @param node The needed HeFS node.
 /// @return False if invalid, nah? calls Seek(node, 0).
 _Output Bool HeFileSystemMgr::Rewind(NodePtr node) {
-  if (!node) return false;
-  return true;
+  if (!node) return NO;
+
+  return this->Seek(node, 0UL);
 }
 
 /// @brief Returns the parser of OpenHeFS.

--- a/private/minkernel/src/FS/OpenHeFS+FileSystemParser.cpp
+++ b/private/minkernel/src/FS/OpenHeFS+FileSystemParser.cpp
@@ -355,7 +355,9 @@ namespace Detail {
                 break;
               }
 
-              hefsi_traverse_tree(tmpend, mnt, boot->fStartIND, child_first);
+              child_first += sizeof(HEFS_INDEX_NODE_DIRECTORY);
+
+              if (child_first == 0UL || child_first >= boot->fEndIND) break;
             }
           }
 
@@ -439,7 +441,7 @@ namespace Detail {
 
         prev_location = start;
 
-        hefsi_traverse_tree(tmpdir, mnt, boot->fStartIND, start);
+        start += sizeof(HEFS_INDEX_NODE_DIRECTORY);
         if (start > boot->fEndIND || start == 0) break;
       }
 
@@ -518,8 +520,11 @@ namespace Detail {
           }
         }
 
-        hefsi_traverse_tree(dir, mnt, boot->fStartIND, start);
-        if (start == boot->fStartIND || start == boot->fStartIND) break;
+        /// @note the sibling links are all stamped with fStartIND, walking them
+        /// never advances. Scan the IND region instead.
+        start += sizeof(HEFS_INDEX_NODE_DIRECTORY);
+
+        if (start >= boot->fEndIND) break;
       }
 
       delete node;
@@ -624,8 +629,9 @@ namespace Detail {
               node->fOffsetSliceLow  = 0;
               node->fOffsetSliceHigh = 0;
 
-              boot->fStartIN -= sizeof(HEFS_INDEX_NODE);
-              boot->fStartBlock -= kOpenHeFSBlockLen;
+              /// @note the cursors are bump allocators, rewinding them here hands the next
+              /// create an inode and a block that a live file still owns. Leak until there
+              /// is a free list.
 
               boot->fChecksum = ke_calculate_crc32((Char*) boot, sizeof(HEFS_BOOT_NODE));
 
@@ -661,7 +667,7 @@ namespace Detail {
           }
         }
 
-        hefsi_traverse_tree(dir, mnt, boot->fStartIND, start);
+        start += sizeof(HEFS_INDEX_NODE_DIRECTORY);
         if (start > boot->fEndIND || start == 0) break;
       }
 
@@ -734,7 +740,7 @@ namespace Detail {
           mnt->fOutput(mnt->fPacket);
         }
 
-        hefsi_traverse_tree(dir, mnt, boot->fStartIND, start);
+        start += sizeof(HEFS_INDEX_NODE_DIRECTORY);
       }
 
       err_global_get() = kErrorSuccess;
@@ -890,8 +896,7 @@ _Output Bool HeFileSystemParser::Format(_Input _Output DriveTrait* mnt, _Input c
   const Utf8Char* kFileMap[] = {u8"/",        u8"/boot",  u8"/system", u8"/network",
                                 u8"/devices", u8"/media", u8"/dev",    (Utf8Char*) nullptr};
 
-  SizeT i = 0;
-  while (kFileMap[++i] != nullptr) {
+  for (SizeT i = 0UL; kFileMap[i] != nullptr; ++i) {
     this->CreateINodeDirectory(mnt, kOpenHeFSEncodingFlagsUTF8, kFileMap[i]);
   }
 
@@ -1020,7 +1025,14 @@ _Output Bool HeFileSystemParser::INodeManip(_Input DriveTrait* mnt, VoidPtr bloc
 
   auto start = Detail::hefsi_fetch_in(boot, mnt, dir, name, kind);
 
-  if (start) {
+  if (!start) {
+    mm_free_ptr((VoidPtr) boot);
+    err_global_get() = kErrorFileNotFound;
+
+    return NO;
+  }
+
+  {
     (Void)(kout << hex_number(start->fHashPath) << kendl);
     (Void)(kout << hex_number(start->fOffsetSliceLow) << kendl);
 
@@ -1048,6 +1060,55 @@ _Output Bool HeFileSystemParser::INodeManip(_Input DriveTrait* mnt, VoidPtr bloc
 
   mm_free_ptr((VoidPtr) boot);
   delete start;
+  return YES;
+}
+
+/// @brief Tell whether an inode exists under a directory.
+/// @param mnt The mnt to read from.
+/// @param dir The directory holding the file.
+/// @param name The name of the file.
+/// @param kind The kind it must match.
+/// @return If it was found, see err_global_get().
+_Output Bool HeFileSystemParser::INodeExists(_Input DriveTrait* mnt, const Utf8Char* dir,
+                                             const Utf8Char* name, const UInt8 kind) {
+  if (!mnt || !dir || !name) return NO;
+
+  if (urt_string_len(dir) > kOpenHeFSFileNameLen) return NO;
+  if (urt_string_len(name) > kOpenHeFSFileNameLen) return NO;
+
+  HEFS_BOOT_NODE* boot = (HEFS_BOOT_NODE*) mm_alloc_ptr(sizeof(HEFS_BOOT_NODE), Yes, No);
+
+  if (!boot) {
+    err_global_get() = kErrorInvalidData;
+    return NO;
+  }
+
+  mnt->fPacket.fPacketLba     = mnt->fLbaStart;
+  mnt->fPacket.fPacketSize    = sizeof(HEFS_BOOT_NODE);
+  mnt->fPacket.fPacketContent = boot;
+
+  mnt->fInput(mnt->fPacket);
+
+  if (!KStringBuilder::Equals(boot->fMagic, kOpenHeFSMagic) || boot->fVersion != kOpenHeFSVersion) {
+    mm_free_ptr((VoidPtr) boot);
+    err_global_get() = kErrorDisk;
+
+    return NO;
+  }
+
+  auto node = Detail::hefsi_fetch_in(boot, mnt, dir, name, kind);
+
+  mm_free_ptr((VoidPtr) boot);
+
+  if (!node) {
+    err_global_get() = kErrorFileNotFound;
+    return NO;
+  }
+
+  delete node;
+
+  err_global_get() = kErrorSuccess;
+
   return YES;
 }
 

--- a/private/minkernel/src/HeapMgr.cpp
+++ b/private/minkernel/src/HeapMgr.cpp
@@ -64,18 +64,31 @@ namespace Detail {
     UInt8 fPadding[kHeapMgrAlignSz];
   };
 
-  /// @brief Check for heap address validity.
+  typedef MM_INFORMATION_BLOCK* MM_INFORMATION_BLOCK_PTR;
+
+  /// @brief Distance between a bitmap block base and the pointer we hand out.
+  /// @note the first header steps over the bitmap's own magic/size/used words.
+  inline constexpr auto kHeapMgrHdrSz = sizeof(MM_INFORMATION_BLOCK) * 2;
+
+  static_assert(sizeof(MM_INFORMATION_BLOCK) > sizeof(UIntPtr) * 3,
+                "heap header would overwrite the bitmap header");
+
+  /// @brief Check that a heap pointer still refers to a live allocation.
   /// @return Bool if the pointer is valid or not.
   /// @param heap_ptr The address_ptr to check.
   _Output auto mm_check_ptr_address(VoidPtr heap_ptr) -> Bool {
-    if (!heap_ptr) return false;
+    if (!heap_ptr) return No;
 
-    IntPtr base_ptr = ((IntPtr) heap_ptr) - sizeof(Detail::MM_INFORMATION_BLOCK);
-    /// Add that check in case we're having an integer underflow. ///
-    return base_ptr < 1;
+    /// Reject anything too low to carry our headers, that would underflow. ///
+    if ((UIntPtr) heap_ptr <= kHeapMgrHdrSz) return No;
+
+    if (!HAL::mm_is_bitmap((VoidPtr) ((UIntPtr) heap_ptr - kHeapMgrHdrSz))) return No;
+
+    auto heap_info_ptr = reinterpret_cast<MM_INFORMATION_BLOCK_PTR>((UIntPtr) heap_ptr -
+                                                                    sizeof(MM_INFORMATION_BLOCK));
+
+    return heap_info_ptr->fMagic == kHeapMgrMagic && heap_info_ptr->fPresent;
   }
-
-  typedef MM_INFORMATION_BLOCK* MM_INFORMATION_BLOCK_PTR;
 }  // namespace Detail
 
 STATIC PageMgr kPageMgr;
@@ -95,7 +108,8 @@ _Output VoidPtr mm_alloc_ptr(SizeT sz, Bool wr, Bool user, SizeT pad_amount) {
 
   kAllocationLocked = true;
 
-  sz_fix += sizeof(Detail::MM_INFORMATION_BLOCK);
+  /// @note the block has to cover both headers, not just ours.
+  sz_fix += Detail::kHeapMgrHdrSz;
 
   PTEWrapper wrapper = kPageMgr.Request(wr, user, 
                   No, sz_fix, pad_amount);
@@ -179,58 +193,48 @@ _Output UInt64 mm_get_ptr_flags(VoidPtr heap_ptr) {
 _Output Int32 mm_free_ptr(VoidPtr heap_ptr) {
   if (!heap_ptr) return kErrorHeapNotPresent;
 
-  if (Detail::mm_check_ptr_address(heap_ptr) == No) return kErrorHeapNotPresent;
+  if ((UIntPtr) heap_ptr <= Detail::kHeapMgrHdrSz) return kErrorHeapNotPresent;
+
+  VoidPtr base_ptr = (VoidPtr) ((UIntPtr) heap_ptr - Detail::kHeapMgrHdrSz);
+
+  if (!HAL::mm_is_bitmap(base_ptr)) return kErrorHeapNotPresent;
 
   Detail::MM_INFORMATION_BLOCK_PTR heap_info_ptr =
       reinterpret_cast<Detail::MM_INFORMATION_BLOCK_PTR>((UIntPtr) (heap_ptr) -
                                                          sizeof(Detail::MM_INFORMATION_BLOCK));
 
-  if (heap_info_ptr && heap_info_ptr->fMagic == kHeapMgrMagic) {
-    if (!heap_info_ptr->fPresent) {
-      return kErrorHeapNotPresent;
-    }
+  if (heap_info_ptr->fMagic != kHeapMgrMagic) return kErrorHeapNotPresent;
 
-    heap_info_ptr->fSize      = 0UL;
-    heap_info_ptr->fPresent   = No;
-    heap_info_ptr->fOffset    = 0;
-    heap_info_ptr->fCRC32     = 0;
-    heap_info_ptr->fWriteRead = No;
-    heap_info_ptr->fUser      = No;
-    heap_info_ptr->fMagic     = 0;
-    heap_info_ptr->fPad       = 0;
-
-    (Void)(kout << "HeapMgr: Freed heap address: "
-                << hex_number(reinterpret_cast<UIntPtr>(heap_info_ptr)) << kendl);
-
-    PTEWrapper page_wrapper(
-        No, No, No,
-        reinterpret_cast<UIntPtr>(heap_info_ptr) - sizeof(Detail::MM_INFORMATION_BLOCK));
-
-    Ref<PTEWrapper> pte_address{page_wrapper};
-
-    kPageMgr.Free(pte_address);
-
-    return kErrorSuccess;
-  } else {
+  /// @note the magic survives a free, so a second one lands here.
+  if (!heap_info_ptr->fPresent) {
     ke_stop(RUNTIME_CHECK_TLS, "Double-Free Detected on HeapMgr, aborting.");
   }
 
-  return kErrorInternal;
+  heap_info_ptr->fSize      = 0UL;
+  heap_info_ptr->fPresent   = No;
+  heap_info_ptr->fOffset    = 0;
+  heap_info_ptr->fCRC32     = 0;
+  heap_info_ptr->fWriteRead = No;
+  heap_info_ptr->fUser      = No;
+  heap_info_ptr->fPad       = 0;
+
+  (Void)(kout << "HeapMgr: Freed heap address: "
+              << hex_number(reinterpret_cast<UIntPtr>(heap_info_ptr)) << kendl);
+
+  PTEWrapper page_wrapper(No, No, No, reinterpret_cast<UIntPtr>(base_ptr));
+
+  Ref<PTEWrapper> pte_address{page_wrapper};
+
+  kPageMgr.Free(pte_address);
+
+  return kErrorSuccess;
 }
 
 /// @brief Check if pointer is a valid Ne::Kernel pointer.
 /// @param heap_ptr the pointer
 /// @return if it exists.
 _Output Boolean mm_is_valid_ptr(VoidPtr heap_ptr) {
-  if (heap_ptr && HAL::mm_is_bitmap(heap_ptr)) {
-    Detail::MM_INFORMATION_BLOCK_PTR heap_info_ptr =
-        reinterpret_cast<Detail::MM_INFORMATION_BLOCK_PTR>((UIntPtr) (heap_ptr) -
-                                                           sizeof(Detail::MM_INFORMATION_BLOCK));
-
-    return (heap_info_ptr && heap_info_ptr->fPresent && heap_info_ptr->fMagic == kHeapMgrMagic);
-  }
-
-  return No;
+  return Detail::mm_check_ptr_address(heap_ptr);
 }
 
 /// @brief Protect the heap with a CRC value.

--- a/private/minkernel/src/IPEFDylibObject.cpp
+++ b/private/minkernel/src/IPEFDylibObject.cpp
@@ -46,21 +46,22 @@ EXTERN_C IDylibRef rtl_init_dylib_pef(UserProcess& process) {
     return nullptr;
   }
 
-  dll_obj->Mount(new IPEFDylibObject::DylibTraits());
+  auto traits = new IPEFDylibObject::DylibTraits();
 
-  if (!dll_obj->Get()) {
+  if (!traits) {
     tls_delete_class(dll_obj);
-    dll_obj = nullptr;
-
     process.Crash();
 
     return nullptr;
   }
 
-  dll_obj->Get()->ImageObject = process.Image.LeakBlob().Leak().Leak();
+  traits->ImageObject = process.Image.LeakBlob().Leak().Leak();
+  traits->ImageSz     = process.Image.LeakBlobSz();
 
-  if (!dll_obj->Get()->ImageObject) {
-    delete dll_obj->Get();
+  dll_obj->Mount(traits);
+
+  if (!dll_obj->Get()) {
+    delete traits;
 
     tls_delete_class(dll_obj);
     dll_obj = nullptr;

--- a/private/minkernel/src/PE32CodeMgr.cpp
+++ b/private/minkernel/src/PE32CodeMgr.cpp
@@ -309,8 +309,7 @@ ErrorOr<VoidPtr> PE32Loader::FindStart() {
 
   if (!opt || !opt->AddressOfEntryPoint) return ErrorOr<VoidPtr>(kErrorExecutable);
 
-  return ErrorOr<VoidPtr>{
-      (VoidPtr) ((UIntPtr) image.Leak().Leak() + opt->AddressOfEntryPoint)};
+  return ErrorOr<VoidPtr>{(VoidPtr) (opt->ImageBase + opt->AddressOfEntryPoint)};
 }
 
 /// @brief Tells if the executable is loaded or not.

--- a/private/minkernel/src/PE32CodeMgr.cpp
+++ b/private/minkernel/src/PE32CodeMgr.cpp
@@ -7,6 +7,7 @@
 #include <KernelKit/DebugOutput.h>
 #include <KernelKit/HeapMgr.h>
 #include <KernelKit/PE32CodeMgr.h>
+#include <KernelKit/PhysicalMemory.h>
 #include <KernelKit/ProcessScheduler.h>
 #include <NeKit/Config.h>
 #include <NeKit/KString.h>
@@ -46,6 +47,13 @@ namespace Detail {
 #else
     return 0;
 #endif
+  }
+
+  /// @brief Unmap n pages from base, handing the frames back.
+  STATIC Void ldr_unmap_pages(UIntPtr base, SizeT n) {
+    while (n-- > 0) {
+      HAL::pmm_free_frame(HAL::mm_unmap_page((VoidPtr) (base + (n * kPageSize))));
+    }
   }
 }  // namespace Detail
 
@@ -251,11 +259,22 @@ ErrorOr<VoidPtr> PE32Loader::LoadImage() {
 
   if (!header || !opt || header->NumberOfSections < 1) return ErrorOr<VoidPtr>{kErrorInvalidData};
 
-  auto image = new Char[opt->SizeOfImage];
+  SizeT pages = opt->SizeOfImage / kPageSize + ((opt->SizeOfImage % kPageSize) ? 1 : 0);
 
-  if (!image) return ErrorOr<VoidPtr>{kErrorHeapOutOfMemory};
+  /// @note frames back the image, the heap is not page aligned and the PTE
+  /// would silently shift the whole view. Frames come zeroed, so BSS is done.
+  for (SizeT i = 0UL; i < pages; ++i) {
+    auto frame = HAL::pmm_alloc_frame();
 
-  rt_set_memory(image, 0, opt->SizeOfImage);
+    if (!frame || HAL::mm_map_page((VoidPtr) (opt->ImageBase + (i * kPageSize)), (VoidPtr) frame,
+                                   HAL::kMMFlagsPresent | HAL::kMMFlagsWr | HAL::kMMFlagsUser) !=
+                      kErrorSuccess) {
+      HAL::pmm_free_frame(frame);
+      Detail::ldr_unmap_pages(opt->ImageBase, i);
+
+      return ErrorOr<VoidPtr>{kErrorHeapOutOfMemory};
+    }
+  }
 
   auto sect =
       reinterpret_cast<LDR_SECTION_HEADER_PTR>(((Char*) opt) + header->SizeOfOptionalHeader);
@@ -270,31 +289,17 @@ ErrorOr<VoidPtr> PE32Loader::LoadImage() {
         sec->SizeOfRawData > opt->SizeOfImage - sec->VirtualAddress ||
         sec->PointerToRawData > fCachedBlobSz ||
         sec->SizeOfRawData > fCachedBlobSz - sec->PointerToRawData) {
-      delete[] image;
+      Detail::ldr_unmap_pages(opt->ImageBase, pages);
 
       return ErrorOr<VoidPtr>{kErrorInvalidData};
     }
 
     rt_copy_memory_safe((VoidPtr) (blob + sec->PointerToRawData),
-                        (VoidPtr) (image + sec->VirtualAddress), sec->SizeOfRawData,
+                        (VoidPtr) (opt->ImageBase + sec->VirtualAddress), sec->SizeOfRawData,
                         opt->SizeOfImage - sec->VirtualAddress);
   }
 
-  SizeT pages = opt->SizeOfImage / kPageSize + ((opt->SizeOfImage % kPageSize) ? 1 : 0);
-
-  for (SizeT i = 0UL; i < pages; ++i) {
-    auto rc = HAL::mm_map_page((VoidPtr) (opt->ImageBase + (i * kPageSize)),
-                               (VoidPtr) (HAL::mm_get_page_addr(image) + (i * kPageSize)),
-                               HAL::kMMFlagsPresent | HAL::kMMFlagsUser);
-
-    if (rc != kErrorSuccess) {
-      delete[] image;
-
-      return ErrorOr<VoidPtr>{kErrorInvalidData};
-    }
-  }
-
-  fImage = image;
+  fImage = (VoidPtr) opt->ImageBase;
 
   (Void)(kout << "PE32Loader: info: Mapped image at " << hex_number(opt->ImageBase) << kendl);
 

--- a/private/minkernel/src/PE32CodeMgr.cpp
+++ b/private/minkernel/src/PE32CodeMgr.cpp
@@ -64,7 +64,11 @@ namespace Detail {
 
 PE32Loader::PE32Loader(const VoidPtr blob, const SizeT len)
     : fCachedBlob(blob), fCachedBlobSz(len) {
-  if (!blob || len < sizeof(DosHeader)) {
+  /// @note the headers are laid out back to back, the walk reads all three.
+  constexpr SizeT kMinPeSz =
+      sizeof(DosHeader) + sizeof(LDR_EXEC_HEADER) + sizeof(LDR_OPTIONAL_HEADER);
+
+  if (!blob || len < kMinPeSz) {
     fBad = YES;
     return;
   }
@@ -258,6 +262,13 @@ ErrorOr<VoidPtr> PE32Loader::LoadImage() {
   auto opt    = CF::ldr_find_opt_exec_header(blob);
 
   if (!header || !opt || header->NumberOfSections < 1) return ErrorOr<VoidPtr>{kErrorInvalidData};
+
+  auto sect_off = (SizeT) ((Char*) opt - blob) + header->SizeOfOptionalHeader;
+
+  if (sect_off > fCachedBlobSz ||
+      header->NumberOfSections > (fCachedBlobSz - sect_off) / sizeof(LDR_SECTION_HEADER)) {
+    return ErrorOr<VoidPtr>{kErrorInvalidData};
+  }
 
   SizeT pages = opt->SizeOfImage / kPageSize + ((opt->SizeOfImage % kPageSize) ? 1 : 0);
 

--- a/private/minkernel/src/PE32CodeMgr.cpp
+++ b/private/minkernel/src/PE32CodeMgr.cpp
@@ -249,8 +249,7 @@ ErrorOr<VoidPtr> PE32Loader::LoadImage() {
   auto header = CF::ldr_find_exec_header(blob);
   auto opt    = CF::ldr_find_opt_exec_header(blob);
 
-  if (!header || !opt || header->NumberOfSections < 1)
-    return ErrorOr<VoidPtr>{kErrorInvalidData};
+  if (!header || !opt || header->NumberOfSections < 1) return ErrorOr<VoidPtr>{kErrorInvalidData};
 
   auto image = new Char[opt->SizeOfImage];
 
@@ -289,7 +288,6 @@ ErrorOr<VoidPtr> PE32Loader::LoadImage() {
                                HAL::kMMFlagsPresent | HAL::kMMFlagsUser);
 
     if (rc != kErrorSuccess) {
-
       delete[] image;
 
       return ErrorOr<VoidPtr>{kErrorInvalidData};
@@ -350,52 +348,51 @@ ErrorOr<VoidPtr> PE32Loader::GetBlob() {
 }
 
 ProcessID rtl_create_user_process(PE32Loader&                        exec,
-                                    const UserProcess::ExecutableKind& process_kind) {
-    if (!exec.IsLoaded()) return kCPSInvalidPID;
+                                  const UserProcess::ExecutableKind& process_kind) {
+  if (!exec.IsLoaded()) return kCPSInvalidPID;
 
-    ErrorOrAny errOrStart = exec.FindStart();
+  ErrorOrAny errOrStart = exec.FindStart();
 
-    if (errOrStart.Error() != kErrorSuccess) return kCPSInvalidPID;
+  if (errOrStart.Error() != kErrorSuccess) return kCPSInvalidPID;
 
-    ErrorOrAny symname = exec.FindSymbol(kPeNameSymbol, 0);
+  ErrorOrAny symname = exec.FindSymbol(kPeNameSymbol, 0);
 
-    if (!symname.Leak().Leak())
-      symname = ErrorOr<VoidPtr>{(VoidPtr) rt_alloc_string(kPeImageStart)};
+  if (!symname.Leak().Leak()) symname = ErrorOr<VoidPtr>{(VoidPtr) rt_alloc_string(kPeImageStart)};
 
-    if (!symname.Leak().Leak()) return kCPSInvalidPID;
+  if (!symname.Leak().Leak()) return kCPSInvalidPID;
 
-    ProcessID id =
-        UserProcessScheduler::The().Spawn(reinterpret_cast<const Char*>(symname.Leak().Leak()),
-                                          errOrStart.Leak().Leak(), exec.GetBlob().Leak().Leak());
+  ProcessID id =
+      UserProcessScheduler::The().Spawn(reinterpret_cast<const Char*>(symname.Leak().Leak()),
+                                        errOrStart.Leak().Leak(), exec.GetBlob().Leak().Leak());
 
-    mm_free_ptr(symname.Leak().Leak());
+  mm_free_ptr(symname.Leak().Leak());
 
-    if (id != kCPSInvalidPID) {
-      auto stacksym = exec.FindSymbol(kPeStackSizeSymbol, 0);
+  if (id != kCPSInvalidPID) {
+    auto stacksym = exec.FindSymbol(kPeStackSizeSymbol, 0);
 
-      if (!stacksym.Leak().Leak()) {
-        stacksym = ErrorOr<VoidPtr>{(VoidPtr) new UIntPtr(kCPSMaxStackSz)};
-      }
-
-      if (!stacksym.Leak().Leak()) {
-        UserProcessScheduler::The().Remove(id);
-        mm_free_ptr(stacksym.Leak().Leak());
-        return kCPSInvalidPID;
-      }
-
-      if ((*(volatile UIntPtr*) stacksym.Leak().Leak()) > kCPSMaxStackSz) {
-        *(volatile UIntPtr*) stacksym.Leak().Leak() = kCPSMaxStackSz;
-      }
-
-      UserProcessScheduler::The().TheCurrentTeam().AsArray()[id].Kind = process_kind;
-      UserProcessScheduler::The().TheCurrentTeam().AsArray()[id].StackSize =
-          *(UIntPtr*) stacksym.Leak().Leak();
-
-      mm_free_ptr(stacksym.Leak().Leak());
-      stacksym.Leak().Leak() = nullptr;
+    if (!stacksym.Leak().Leak()) {
+      stacksym = ErrorOr<VoidPtr>{(VoidPtr) new UIntPtr(kCPSMaxStackSz)};
     }
 
-    return id;
+    if (!stacksym.Leak().Leak()) {
+      UserProcessScheduler::The().Remove(id);
+      mm_free_ptr(stacksym.Leak().Leak());
+      return kCPSInvalidPID;
+    }
+
+    if ((*(volatile UIntPtr*) stacksym.Leak().Leak()) > kCPSMaxStackSz) {
+      *(volatile UIntPtr*) stacksym.Leak().Leak() = kCPSMaxStackSz;
+    }
+
+    UserProcessScheduler::The().TheCurrentTeam().AsArray()[id].Kind = process_kind;
+    UserProcessScheduler::The().TheCurrentTeam().AsArray()[id].StackSize =
+        *(UIntPtr*) stacksym.Leak().Leak();
+
+    mm_free_ptr(stacksym.Leak().Leak());
+    stacksym.Leak().Leak() = nullptr;
   }
+
+  return id;
+}
 
 }  // namespace Ne::Kernel

--- a/private/minkernel/src/PE32CodeMgr.cpp
+++ b/private/minkernel/src/PE32CodeMgr.cpp
@@ -36,6 +36,17 @@ namespace Detail {
     return kPEPlatformInvalid;
 #endif  // __32x0__ || __64x0__ || __x86_64__
   }
+
+  /// @brief COFF machine value this build can execute.
+  UInt16 ldr_get_platform_pe_machine(void) {
+#if defined(__NE_AMD64__)
+    return kPeMachineAMD64;
+#elif defined(__NE_ARM64__)
+    return kPeMachineARM64;
+#else
+    return 0;
+#endif
+  }
 }  // namespace Detail
 
 /***********************************************************************************/
@@ -43,8 +54,35 @@ namespace Detail {
 /// @param blob file blob.
 /***********************************************************************************/
 
-PE32Loader::PE32Loader(const VoidPtr blob) : fCachedBlob(blob) {
-  fBad = false;
+PE32Loader::PE32Loader(const VoidPtr blob, const SizeT len)
+    : fCachedBlob(blob), fCachedBlobSz(len) {
+  if (!blob || len < sizeof(DosHeader)) {
+    fBad = YES;
+    return;
+  }
+
+  auto header = CF::ldr_find_exec_header(reinterpret_cast<const Char*>(blob));
+  auto opt    = CF::ldr_find_opt_exec_header(reinterpret_cast<const Char*>(blob));
+
+  if (!header || !opt) {
+    fBad = YES;
+    return;
+  }
+
+  if (header->Machine != Detail::ldr_get_platform_pe_machine()) {
+    fBad = YES;
+    return;
+  }
+
+  if (opt->Subsystem != kNeKernelPESubsystem) {
+    fBad = YES;
+    return;
+  }
+
+  if (opt->SizeOfImage < 1 || opt->SizeOfImage > kPeMaxImageSz) {
+    fBad = YES;
+    return;
+  }
 }
 
 /***********************************************************************************/
@@ -196,10 +234,83 @@ ErrorOr<VoidPtr> PE32Loader::FindSymbol(const Char* name, Int32 kind) {
 
 /// @brief Finds the executable entrypoint.
 /// @return
-ErrorOr<VoidPtr> PE32Loader::FindStart() {
-  if (auto sym = this->FindSymbol(kPeImageStart, 0); sym) return sym;
+/***********************************************************************************/
+/// @brief Instantiate the image and map it at its preferred base.
+/// @return the kernel address of the image.
+/***********************************************************************************/
 
-  return ErrorOr<VoidPtr>(kErrorExecutable);
+ErrorOr<VoidPtr> PE32Loader::LoadImage() {
+  if (fImage) return ErrorOr<VoidPtr>{fImage};
+
+  if (fBad || !fCachedBlob.Leak().Leak() || !fCachedBlobSz)
+    return ErrorOr<VoidPtr>{kErrorInvalidData};
+
+  auto blob   = reinterpret_cast<Char*>(fCachedBlob.Leak().Leak());
+  auto header = CF::ldr_find_exec_header(blob);
+  auto opt    = CF::ldr_find_opt_exec_header(blob);
+
+  if (!header || !opt || header->NumberOfSections < 1)
+    return ErrorOr<VoidPtr>{kErrorInvalidData};
+
+  auto image = new Char[opt->SizeOfImage];
+
+  if (!image) return ErrorOr<VoidPtr>{kErrorHeapOutOfMemory};
+
+  rt_set_memory(image, 0, opt->SizeOfImage);
+
+  auto sect =
+      reinterpret_cast<LDR_SECTION_HEADER_PTR>(((Char*) opt) + header->SizeOfOptionalHeader);
+
+  for (SizeT i = 0UL; i < header->NumberOfSections; ++i) {
+    auto sec = &sect[i];
+
+    if (!sec->SizeOfRawData) continue;
+
+    /// @note never a + b, both sums are free to wrap.
+    if (sec->VirtualAddress > opt->SizeOfImage ||
+        sec->SizeOfRawData > opt->SizeOfImage - sec->VirtualAddress ||
+        sec->PointerToRawData > fCachedBlobSz ||
+        sec->SizeOfRawData > fCachedBlobSz - sec->PointerToRawData) {
+      delete[] image;
+
+      return ErrorOr<VoidPtr>{kErrorInvalidData};
+    }
+
+    rt_copy_memory_safe((VoidPtr) (blob + sec->PointerToRawData),
+                        (VoidPtr) (image + sec->VirtualAddress), sec->SizeOfRawData,
+                        opt->SizeOfImage - sec->VirtualAddress);
+  }
+
+  SizeT pages = opt->SizeOfImage / kPageSize + ((opt->SizeOfImage % kPageSize) ? 1 : 0);
+
+  for (SizeT i = 0UL; i < pages; ++i) {
+    if (HAL::mm_map_page((VoidPtr) (opt->ImageBase + (i * kPageSize)),
+                         (VoidPtr) (HAL::mm_get_page_addr(image) + (i * kPageSize)),
+                         HAL::kMMFlagsPresent | HAL::kMMFlagsUser) != kErrorSuccess) {
+      delete[] image;
+
+      return ErrorOr<VoidPtr>{kErrorInvalidData};
+    }
+  }
+
+  fImage = image;
+
+  (Void)(kout << "PE32Loader: info: Mapped image at " << hex_number(opt->ImageBase) << kendl);
+
+  return ErrorOr<VoidPtr>{fImage};
+}
+
+ErrorOr<VoidPtr> PE32Loader::FindStart() {
+  auto image = this->LoadImage();
+
+  if (!image.Leak().Leak()) return ErrorOr<VoidPtr>(kErrorExecutable);
+
+  auto opt = CF::ldr_find_opt_exec_header(reinterpret_cast<Char*>(fCachedBlob.Leak().Leak()));
+
+  if (!opt || !opt->AddressOfEntryPoint) return ErrorOr<VoidPtr>(kErrorExecutable);
+
+  return ErrorOr<VoidPtr>{
+      (VoidPtr) ((UIntPtr) image.Leak().Leak() + opt->AddressOfEntryPoint)};
 }
 
 /// @brief Tells if the executable is loaded or not.
@@ -236,8 +347,7 @@ ErrorOr<VoidPtr> PE32Loader::GetBlob() {
   return ErrorOr<VoidPtr>{this->fCachedBlob.Leak().Leak()};
 }
 
-namespace Utils {
-  ProcessID rtl_create_user_process(PE32Loader&                        exec,
+ProcessID rtl_create_user_process(PE32Loader&                        exec,
                                     const UserProcess::ExecutableKind& process_kind) {
     if (!exec.IsLoaded()) return kCPSInvalidPID;
 
@@ -275,8 +385,8 @@ namespace Utils {
         *(volatile UIntPtr*) stacksym.Leak().Leak() = kCPSMaxStackSz;
       }
 
-      UserProcessScheduler::The().TheCurrentTeam().Leak().AsArray()[id].Kind = process_kind;
-      UserProcessScheduler::The().TheCurrentTeam().Leak().AsArray()[id].StackSize =
+      UserProcessScheduler::The().TheCurrentTeam().AsArray()[id].Kind = process_kind;
+      UserProcessScheduler::The().TheCurrentTeam().AsArray()[id].StackSize =
           *(UIntPtr*) stacksym.Leak().Leak();
 
       mm_free_ptr(stacksym.Leak().Leak());
@@ -285,6 +395,5 @@ namespace Utils {
 
     return id;
   }
-}  // namespace Utils
 
 }  // namespace Ne::Kernel

--- a/private/minkernel/src/PE32CodeMgr.cpp
+++ b/private/minkernel/src/PE32CodeMgr.cpp
@@ -284,9 +284,12 @@ ErrorOr<VoidPtr> PE32Loader::LoadImage() {
   SizeT pages = opt->SizeOfImage / kPageSize + ((opt->SizeOfImage % kPageSize) ? 1 : 0);
 
   for (SizeT i = 0UL; i < pages; ++i) {
-    if (HAL::mm_map_page((VoidPtr) (opt->ImageBase + (i * kPageSize)),
-                         (VoidPtr) (HAL::mm_get_page_addr(image) + (i * kPageSize)),
-                         HAL::kMMFlagsPresent | HAL::kMMFlagsUser) != kErrorSuccess) {
+    auto rc = HAL::mm_map_page((VoidPtr) (opt->ImageBase + (i * kPageSize)),
+                               (VoidPtr) (HAL::mm_get_page_addr(image) + (i * kPageSize)),
+                               HAL::kMMFlagsPresent | HAL::kMMFlagsUser);
+
+    if (rc != kErrorSuccess) {
+
       delete[] image;
 
       return ErrorOr<VoidPtr>{kErrorInvalidData};

--- a/private/minkernel/src/PEFCodeMgr.cpp
+++ b/private/minkernel/src/PEFCodeMgr.cpp
@@ -7,6 +7,7 @@
 #include <KernelKit/DebugOutput.h>
 #include <KernelKit/HeapMgr.h>
 #include <KernelKit/PEFCodeMgr.h>
+#include <KernelKit/PhysicalMemory.h>
 #include <KernelKit/ProcessScheduler.h>
 #include <NeKit/Config.h>
 #include <NeKit/KString.h>
@@ -143,7 +144,9 @@ namespace Detail {
       if (out->Cpu != ldr_get_platform() && !kIsFat) return NO;
 
       if (out->VMSize < 1 || out->VMSize > kPefMaxImageSz) return NO;
+      /// @note sections live inside the image window, the heap owns everything past it.
       if (out->VMAddress < kPefBaseOrigin) return NO;
+      if (out->VMAddress - kPefBaseOrigin > kPefMaxImageSz - out->VMSize) return NO;
       if (out->OffsetSize > out->VMSize) return NO;
 
       if (out->OffsetSize > 0) {
@@ -159,30 +162,35 @@ namespace Detail {
     return NO;
   }
 
-  /// @brief Instantiate a section, then map it at its virtual address.
-  STATIC ErrorOr<VoidPtr> pef_load_section(const PEFCommandHeader& hdr, const VoidPtr src) {
-    Char* image = new Char[hdr.VMSize];
-
-    if (!image) return ErrorOr<VoidPtr>{kErrorHeapOutOfMemory};
-
-    rt_set_memory(image, 0, hdr.VMSize);
-
-    if (src && hdr.OffsetSize > 0) {
-      rt_copy_memory_safe(src, image, hdr.OffsetSize, hdr.VMSize);
+  /// @brief Unmap n pages from base, handing the frames back.
+  STATIC Void ldr_unmap_pages(UIntPtr base, SizeT n) {
+    while (n-- > 0) {
+      HAL::pmm_free_frame(HAL::mm_unmap_page((VoidPtr) (base + (n * kPageSize))));
     }
+  }
 
+  /// @brief Instantiate a section at its virtual address, backed by frames.
+  STATIC ErrorOr<VoidPtr> pef_load_section(const PEFCommandHeader& hdr, const VoidPtr src) {
     SizeT pages = hdr.VMSize / kPageSize + ((hdr.VMSize % kPageSize) ? 1 : 0);
 
     for (SizeT i = 0UL; i < pages; ++i) {
-      if (HAL::mm_map_page((VoidPtr) (hdr.VMAddress + (i * kPageSize)),
-                           (VoidPtr) (HAL::mm_get_page_addr(image) + (i * kPageSize)),
-                           HAL::kMMFlagsPresent | HAL::kMMFlagsUser) != kErrorSuccess) {
-        delete[] image;
-        return ErrorOr<VoidPtr>{kErrorInvalidData};
+      auto frame = HAL::pmm_alloc_frame();
+
+      if (!frame || HAL::mm_map_page((VoidPtr) (hdr.VMAddress + (i * kPageSize)), (VoidPtr) frame,
+                                     HAL::kMMFlagsPresent | HAL::kMMFlagsWr | HAL::kMMFlagsUser) !=
+                        kErrorSuccess) {
+        HAL::pmm_free_frame(frame);
+        ldr_unmap_pages(hdr.VMAddress, i);
+
+        return ErrorOr<VoidPtr>{kErrorHeapOutOfMemory};
       }
     }
 
-    return ErrorOr<VoidPtr>{(VoidPtr) image};
+    if (src && hdr.OffsetSize > 0) {
+      rt_copy_memory_safe(src, (VoidPtr) hdr.VMAddress, hdr.OffsetSize, hdr.VMSize);
+    }
+
+    return ErrorOr<VoidPtr>{(VoidPtr) hdr.VMAddress};
   }
 }  // namespace Detail
 

--- a/private/minkernel/src/PEFCodeMgr.cpp
+++ b/private/minkernel/src/PEFCodeMgr.cpp
@@ -45,14 +45,154 @@ namespace Detail {
     return kPefArchInvalid;
 #endif  // __32x0__ || __64x0__ || __x86_64__
   }
+  /// @brief Compare a container magic against a wanted one.
+  STATIC Bool pef_magic_eq(const Char* magic, const Char* want) {
+    for (SizeT i = 0UL; i < kPefMagicLen - 1; ++i) {
+      if (magic[i] != want[i]) return NO;
+    }
+
+    return YES;
+  }
+
+  /// @brief Compare a fixed size, possibly unterminated, name field.
+  STATIC Bool pef_name_eq(const Char* field, const Char* want) {
+    auto field_len = rt_string_len(field, kPefNameLen);
+
+    if (field_len >= kPefNameLen) return NO;
+
+    auto want_len = rt_string_len(want, kPefNameLen);
+
+    if (want_len != field_len) return NO;
+
+    for (SizeT i = 0UL; i < field_len; ++i) {
+      if (field[i] != want[i]) return NO;
+    }
+
+    return YES;
+  }
+
+  /// @brief Build the section name for a symbol, mangling spaces.
+  STATIC Bool pef_make_name(Char* dst, const SizeT dst_sz, const Int32 kind, const Char* name) {
+    const Char* prefix = nullptr;
+
+    switch (kind) {
+      case kPefCode:
+        prefix = ".code64";
+        break;
+      case kPefData:
+        prefix = ".data64";
+        break;
+      case kPefZero:
+        prefix = ".zero64";
+        break;
+      default:
+        return NO;
+    }
+
+    auto prefix_len = rt_string_len(prefix, dst_sz);
+    auto name_len   = rt_string_len(name, dst_sz);
+
+    if (name_len >= dst_sz - prefix_len) return NO;
+
+    rt_copy_memory((VoidPtr) prefix, dst, prefix_len);
+    rt_copy_memory((VoidPtr) name, dst + prefix_len, name_len);
+
+    for (SizeT i = prefix_len; i < prefix_len + name_len; ++i) {
+      if (rt_is_space(dst[i])) dst[i] = '$';
+    }
+
+    dst[prefix_len + name_len] = 0;
+
+    return YES;
+  }
+
+  /// @brief Validate the container header of a flat blob.
+  STATIC Bool pef_read_container(const UInt8* blob, const SizeT len, PEFContainer* out) {
+    if (!blob || len < sizeof(PEFContainer)) return NO;
+
+    rt_copy_memory((VoidPtr) blob, out, sizeof(PEFContainer));
+
+    if (!pef_magic_eq(out->Magic, kPefMagic) && !pef_magic_eq(out->Magic, kPefMagicFat)) return NO;
+
+    if (out->Abi != kPefAbi) return NO;
+    if (out->Count < 1 || out->Count > kPefMaxSections) return NO;
+
+    /// @note never Count * sizeof(), that product is free to wrap.
+    if (out->Count > (len - sizeof(PEFContainer)) / sizeof(PEFCommandHeader)) return NO;
+
+    return YES;
+  }
+
+  /// @brief Find a section header by name and kind inside a flat blob.
+  STATIC Bool pef_find_section(const UInt8* blob, const SizeT len, const Char* name,
+                               const Int32 kind, PEFCommandHeader* out) {
+    PEFContainer container{};
+
+    if (!pef_read_container(blob, len, &container)) return NO;
+
+    const Bool  kIsFat   = pef_magic_eq(container.Magic, kPefMagicFat);
+    const SizeT kTableSz = container.Count * sizeof(PEFCommandHeader);
+
+    for (SizeT i = 0UL; i < container.Count; ++i) {
+      rt_copy_memory((VoidPtr) (blob + sizeof(PEFContainer) + (i * sizeof(PEFCommandHeader))), out,
+                     sizeof(PEFCommandHeader));
+
+      if (out->Kind != kind) continue;
+      if (!pef_name_eq(out->Name, name)) continue;
+
+      if (out->Cpu != ldr_get_platform() && !kIsFat) return NO;
+
+      if (out->VMSize < 1 || out->VMSize > kPefMaxImageSz) return NO;
+      if (out->VMAddress < kPefBaseOrigin) return NO;
+      if (out->OffsetSize > out->VMSize) return NO;
+
+      if (out->OffsetSize > 0) {
+        if (out->Offset > len) return NO;
+        if (out->OffsetSize > len - out->Offset) return NO;
+        /// @note content may not alias the header table it was validated from.
+        if (out->Offset < sizeof(PEFContainer) + kTableSz) return NO;
+      }
+
+      return YES;
+    }
+
+    return NO;
+  }
+
+  /// @brief Instantiate a section, then map it at its virtual address.
+  STATIC ErrorOr<VoidPtr> pef_load_section(const PEFCommandHeader& hdr, const VoidPtr src) {
+    Char* image = new Char[hdr.VMSize];
+
+    if (!image) return ErrorOr<VoidPtr>{kErrorHeapOutOfMemory};
+
+    rt_set_memory(image, 0, hdr.VMSize);
+
+    if (src && hdr.OffsetSize > 0) {
+      rt_copy_memory_safe(src, image, hdr.OffsetSize, hdr.VMSize);
+    }
+
+    SizeT pages = hdr.VMSize / kPageSize + ((hdr.VMSize % kPageSize) ? 1 : 0);
+
+    for (SizeT i = 0UL; i < pages; ++i) {
+      if (HAL::mm_map_page((VoidPtr) (hdr.VMAddress + (i * kPageSize)),
+                           (VoidPtr) (HAL::mm_get_page_addr(image) + (i * kPageSize)),
+                           HAL::kMMFlagsPresent | HAL::kMMFlagsUser) != kErrorSuccess) {
+        delete[] image;
+        return ErrorOr<VoidPtr>{kErrorInvalidData};
+      }
+    }
+
+    return ErrorOr<VoidPtr>{(VoidPtr) image};
+  }
 }  // namespace Detail
 
 /***********************************************************************************/
 /// @brief PEF loader constructor w/ blob.
 /// @param blob file blob.
+/// @param len size of the blob, bounds every walk over it.
 /***********************************************************************************/
-PEFLoader::PEFLoader(const VoidPtr blob) : fCachedBlob(blob) {
-  if (fCachedBlob.Leak().Leak()) {
+PEFLoader::PEFLoader(const VoidPtr blob, const SizeT len) : fCachedBlob(blob), fCachedBlobSz(len) {
+  if (!fCachedBlob.Leak().Leak()) {
     this->fBad = YES;
     return;
   }
@@ -80,7 +220,6 @@ PEFLoader::PEFLoader(const VoidPtr blob) : fCachedBlob(blob) {
   this->fFatBinary = NO;
   this->fBad       = YES;
 
-  if (this->fCachedBlob) mm_free_ptr(this->fCachedBlob.Leak().Leak());
   this->fCachedBlob.Leak().Leak() = nullptr;
 }
 
@@ -102,6 +241,7 @@ PEFLoader::PEFLoader(const Char* path) : fCachedBlob(nullptr), fFatBinary(false)
 
   /// @note zero here means that the FileMgr will read every container header inside the file.
   fCachedBlob = fFile->Read(kPefHeader, 0UL);
+  fOwnsBlob   = YES;
 
   if (!fCachedBlob.Leak().Leak()) {
     kout << "PEFLoader: warning: Binary format error!\r";
@@ -142,7 +282,7 @@ PEFLoader::PEFLoader(const Char* path) : fCachedBlob(nullptr), fFatBinary(false)
 /// @brief PEF destructor.
 /***********************************************************************************/
 PEFLoader::~PEFLoader() {
-  if (fCachedBlob.Leak().Leak()) {
+  if (fOwnsBlob && fCachedBlob.Leak().Leak()) {
     mm_free_ptr(fCachedBlob.Leak().Leak());
   }
 }
@@ -154,6 +294,26 @@ PEFLoader::~PEFLoader() {
 /***********************************************************************************/
 ErrorOr<VoidPtr> PEFLoader::FindSymbol(const Char* name, Int32 kind) {
   if (!fCachedBlob.Leak().Leak() || fBad || !name) return ErrorOr<VoidPtr>{kErrorInvalidData};
+
+  if (fCachedBlobSz > 0) {
+    Char             sect_name[kPefNameLen] = {0};
+    PEFCommandHeader hdr{};
+
+    if (!Detail::pef_make_name(sect_name, kPefNameLen, kind, name))
+      return ErrorOr<VoidPtr>{kErrorInvalidData};
+
+    auto blob_ptr = reinterpret_cast<const UInt8*>(fCachedBlob.Leak().Leak());
+
+    if (!Detail::pef_find_section(blob_ptr, fCachedBlobSz, sect_name, kind, &hdr))
+      return ErrorOr<VoidPtr>{kErrorInvalidData};
+
+    kout << "PEFLoader: info: Load stub: " << hdr.Name << "!\r";
+
+    return Detail::pef_load_section(
+        hdr, hdr.OffsetSize > 0 ? (VoidPtr) (blob_ptr + hdr.Offset) : nullptr);
+  }
+
+  if (!fFile) return ErrorOr<VoidPtr>{kErrorInvalidData};
 
   auto blob = fFile->Read(name, sizeof(PEFCommandHeader));
 
@@ -313,9 +473,9 @@ ProcessID rtl_create_user_process(PEFLoader&                         exec,
 
   if (!symname.Leak().Leak()) return kCPSInvalidPID;
 
-  ProcessID id =
-      UserProcessScheduler::The().Spawn(reinterpret_cast<const Char*>(symname.Leak().Leak()),
-                                        errOrStart.Leak().Leak(), exec.GetBlob().Leak().Leak());
+  ProcessID id = UserProcessScheduler::The().Spawn(
+      reinterpret_cast<const Char*>(symname.Leak().Leak()), errOrStart.Leak().Leak(),
+      exec.GetBlob().Leak().Leak(), exec.BlobSz());
 
   if (symname.Leak().Leak()) mm_free_ptr(symname.Leak().Leak());
 
@@ -336,8 +496,8 @@ ProcessID rtl_create_user_process(PEFLoader&                         exec,
       *(volatile UIntPtr*) stacksym.Leak().Leak() = kCPSMaxStackSz;
     }
 
-    UserProcessScheduler::The().TheCurrentTeam().Leak().AsArray()[id].Kind = process_kind;
-    UserProcessScheduler::The().TheCurrentTeam().Leak().AsArray()[id].StackSize =
+    UserProcessScheduler::The().TheCurrentTeam().AsArray()[id].Kind = process_kind;
+    UserProcessScheduler::The().TheCurrentTeam().AsArray()[id].StackSize =
         *(UIntPtr*) stacksym.Leak().Leak();
 
     mm_free_ptr(stacksym.Leak().Leak());

--- a/private/minkernel/src/PhysicalMemory.cpp
+++ b/private/minkernel/src/PhysicalMemory.cpp
@@ -1,0 +1,99 @@
+#include <KernelKit/DebugOutput.h>
+#include <KernelKit/PhysicalMemory.h>
+#include <NeKit/KernelPanic.h>
+#include <NeKit/Utils.h>
+
+/// @file PhysicalMemory.cpp
+/// @brief Physical frame allocator, the memory page tables are built from.
+
+namespace Ne::Kernel::HAL {
+
+namespace Detail {
+  /// @brief Bump cursor, everything above it inside the region is untouched.
+  STATIC UIntPtr kPmmBase{0UL};
+  STATIC UIntPtr kPmmCursor{0UL};
+  STATIC UIntPtr kPmmEnd{0UL};
+
+  /// @brief Freed frames, threaded through the frames themselves.
+  STATIC UIntPtr kPmmFreeHead{0UL};
+
+  STATIC SizeT kPmmFree{0UL};
+  STATIC SizeT kPmmUsed{0UL};
+
+  inline constexpr auto kPmmAlign = kPageSize - 1;
+}  // namespace Detail
+
+/// @brief Hand a physical region to the frame allocator.
+/// @param base first byte of the region.
+/// @param sz size of the region in bytes.
+Void pmm_init(UIntPtr base, SizeT sz) {
+  auto start = (base + Detail::kPmmAlign) & ~Detail::kPmmAlign;
+  auto end   = (base + sz) & ~Detail::kPmmAlign;
+
+  if (end <= start) {
+    Detail::kPmmCursor = 0UL;
+    Detail::kPmmEnd    = 0UL;
+
+    return;
+  }
+
+  Detail::kPmmBase     = start;
+  Detail::kPmmCursor   = start;
+  Detail::kPmmEnd      = end;
+  Detail::kPmmFreeHead = 0UL;
+  Detail::kPmmFree     = (end - start) / kPageSize;
+  Detail::kPmmUsed     = 0UL;
+
+  (Void)(kout << "pmm_init: base " << hex_number(start) << kendl);
+  (Void)(kout << "pmm_init: frames " << number(Detail::kPmmFree) << kendl);
+}
+
+/// @brief Take one frame.
+/// @return the frame's physical address, zeroed, or 0 when out of memory.
+_Output UIntPtr pmm_alloc_frame(Void) {
+  UIntPtr frame = 0UL;
+
+  if (Detail::kPmmFreeHead) {
+    frame = Detail::kPmmFreeHead;
+
+    Detail::kPmmFreeHead = *reinterpret_cast<UIntPtr*>(frame);
+  } else if (Detail::kPmmCursor && Detail::kPmmCursor < Detail::kPmmEnd) {
+    frame = Detail::kPmmCursor;
+    Detail::kPmmCursor += kPageSize;
+  }
+
+  if (!frame) return 0UL;
+
+  rt_set_memory(reinterpret_cast<VoidPtr>(frame), 0, kPageSize);
+
+  --Detail::kPmmFree;
+  ++Detail::kPmmUsed;
+
+  return frame;
+}
+
+/// @brief Give a frame back.
+/// @param frame the frame's physical address.
+Void pmm_free_frame(UIntPtr frame) {
+  if (!frame || (frame & Detail::kPmmAlign)) return;
+
+  if (frame < Detail::kPmmBase || frame >= Detail::kPmmCursor) return;
+
+  *reinterpret_cast<UIntPtr*>(frame) = Detail::kPmmFreeHead;
+
+  Detail::kPmmFreeHead = frame;
+
+  ++Detail::kPmmFree;
+  --Detail::kPmmUsed;
+}
+
+/// @brief Frames still available.
+_Output SizeT pmm_free_frames(Void) {
+  return Detail::kPmmFree;
+}
+
+/// @brief Frames handed out.
+_Output SizeT pmm_used_frames(Void) {
+  return Detail::kPmmUsed;
+}
+}  // namespace Ne::Kernel::HAL

--- a/private/minkernel/src/PhysicalMemory.cpp
+++ b/private/minkernel/src/PhysicalMemory.cpp
@@ -62,7 +62,14 @@ _Output UIntPtr pmm_alloc_frame(Void) {
     Detail::kPmmCursor += kPageSize;
   }
 
-  if (!frame) return 0UL;
+  if (!frame) {
+    (Void)(kout << "pmm: exhausted base " << hex_number(Detail::kPmmBase) << kendl);
+    (Void)(kout << "pmm: exhausted cur " << hex_number(Detail::kPmmCursor) << kendl);
+    (Void)(kout << "pmm: exhausted end " << hex_number(Detail::kPmmEnd) << kendl);
+    (Void)(kout << "pmm: exhausted head " << hex_number(Detail::kPmmFreeHead) << kendl);
+
+    return 0UL;
+  }
 
   rt_set_memory(reinterpret_cast<VoidPtr>(frame), 0, kPageSize);
 

--- a/private/minkernel/src/User.cpp
+++ b/private/minkernel/src/User.cpp
@@ -6,6 +6,7 @@
 #include <KernelKit/FileMgr.h>
 #include <KernelKit/HeapMgr.h>
 #include <KernelKit/KPC.h>
+#include <KernelKit/PhysicalMemory.h>
 #include <KernelKit/ThreadLocalStorage.h>
 #include <KernelKit/User.h>
 #include <NeKit/KString.h>
@@ -75,7 +76,9 @@ User::User(const UserRingKind& ring_kind, const UserPublicKeyType* user_name)
 ////////////////////////////////////////////////////////////
 User::~User() = default;
 
-Bool User::IsAdult() { return mUserIsAdult; }
+Bool User::IsAdult() {
+  return mUserIsAdult;
+}
 
 Bool User::Save(const UserPublicKey password) {
   if (!password || *password == 0) return No;
@@ -140,11 +143,15 @@ Bool User::IsGuestUser() {
 ////////////////////////////////////////////////////////////
 
 Void user_init_globals(const Bool recovery) {
-  STATIC User kRootStorage{UserRingKind::kRingSuperUser, kRootUserName};
-  STATIC User kGuestStorage{UserRingKind::kRingGuestUser, kGuestUserName};
+  /// @note heap, not function local statics. Those need guard variables and an
+  /// atexit thunk, and this kernel's implementations of both are homegrown.
+  if (!kRootUser) kRootUser = new User(UserRingKind::kRingSuperUser, kRootUserName);
+  if (!kGuest) kGuest = new User(UserRingKind::kRingGuestUser, kGuestUserName);
 
-  kRootUser = &kRootStorage;
-  kGuest    = &kGuestStorage;
+  if (!kRootUser || !kGuest) {
+    (Void)(kout << "user_init_globals: out of memory\r");
+    return;
+  }
 
   kCurrentUser = recovery ? kGuest : kRootUser;
 

--- a/private/minkernel/src/User.cpp
+++ b/private/minkernel/src/User.cpp
@@ -43,6 +43,15 @@ namespace Detail {
 
     return hash;
   }
+  /// @brief Copy a user name, truncating at kMaxUserNameLen.
+  STATIC Void user_set_name(Char* dst, const UserPublicKeyType* src) {
+    auto len = urt_string_len(src);
+
+    if (len >= kMaxUserNameLen) len = kMaxUserNameLen - 1;
+
+    urt_copy_memory((VoidPtr) src, dst, len);
+    dst[len] = 0;
+  }
 }  // namespace Detail
 
 ////////////////////////////////////////////////////////////
@@ -50,7 +59,7 @@ namespace Detail {
 ////////////////////////////////////////////////////////////
 User::User(const Int32& sel, const UserPublicKeyType* user_name) : mUserRing((UserRingKind) sel) {
   MUST_PASS(sel >= 0);
-  urt_copy_memory((VoidPtr) user_name, this->mUserName, urt_string_len(user_name));
+  Detail::user_set_name(this->mUserName, user_name);
 }
 
 ////////////////////////////////////////////////////////////
@@ -58,7 +67,7 @@ User::User(const Int32& sel, const UserPublicKeyType* user_name) : mUserRing((Us
 ////////////////////////////////////////////////////////////
 User::User(const UserRingKind& ring_kind, const UserPublicKeyType* user_name)
     : mUserRing(ring_kind) {
-  urt_copy_memory((VoidPtr) user_name, this->mUserName, urt_string_len(user_name));
+  Detail::user_set_name(this->mUserName, user_name);
 }
 
 ////////////////////////////////////////////////////////////
@@ -119,6 +128,27 @@ Bool User::IsStdUser() {
 
 Bool User::IsSuperUser() {
   return this->Ring() == UserRingKind::kRingSuperUser;
+}
+
+Bool User::IsGuestUser() {
+  return this->Ring() == UserRingKind::kRingGuestUser;
+}
+
+////////////////////////////////////////////////////////////
+/// @brief Binds kRootUser, kGuest and kCurrentUser.
+/// @param recovery make the guest user current instead of root.
+////////////////////////////////////////////////////////////
+
+Void user_init_globals(const Bool recovery) {
+  STATIC User kRootStorage{UserRingKind::kRingSuperUser, kRootUserName};
+  STATIC User kGuestStorage{UserRingKind::kRingGuestUser, kGuestUserName};
+
+  kRootUser = &kRootStorage;
+  kGuest    = &kGuestStorage;
+
+  kCurrentUser = recovery ? kGuest : kRootUser;
+
+  (Void)(kout << "user_init_globals: " << kCurrentUser->Name() << kendl);
 }
 
 }  // namespace Ne::Kernel

--- a/private/minkernel/src/UserProcessScheduler.cpp
+++ b/private/minkernel/src/UserProcessScheduler.cpp
@@ -411,9 +411,9 @@ ProcessID UserProcessScheduler::Spawn(const Char* name, VoidPtr code, VoidPtr im
   process.RTime    = 0;
   process.UTime    = 0;
   process.STime    = 0;
-  process.UTime     = 0;
-  process.RTime     = 0;
-  process.STime     = 0;
+  process.UTime    = 0;
+  process.RTime    = 0;
+  process.STime    = 0;
 
   if (!process.FileTree) {
     process.FileTree = new ProcessFileTree<VoidPtr>();

--- a/private/minkernel/src/UserProcessScheduler.cpp
+++ b/private/minkernel/src/UserProcessScheduler.cpp
@@ -404,6 +404,13 @@ ProcessID UserProcessScheduler::Spawn(const Char* name, VoidPtr code, VoidPtr im
   process.ProcessId = pid;
   process.Status    = ProcessStatusKind::kRunning;
   process.PTime     = 0;
+
+  /// @note the team is copied in from a global whose constructor never ran, so the
+  /// member initialisers are gone. Spawn owns the scheduling state.
+  process.Affinity = AffinityKind::kStandard;
+  process.RTime    = 0;
+  process.UTime    = 0;
+  process.STime    = 0;
   process.UTime     = 0;
   process.RTime     = 0;
   process.STime     = 0;

--- a/private/minkernel/src/UserProcessScheduler.cpp
+++ b/private/minkernel/src/UserProcessScheduler.cpp
@@ -411,9 +411,6 @@ ProcessID UserProcessScheduler::Spawn(const Char* name, VoidPtr code, VoidPtr im
   process.RTime    = 0;
   process.UTime    = 0;
   process.STime    = 0;
-  process.UTime    = 0;
-  process.RTime    = 0;
-  process.STime    = 0;
 
   if (!process.FileTree) {
     process.FileTree = new ProcessFileTree<VoidPtr>();

--- a/private/minkernel/src/UserProcessScheduler.cpp
+++ b/private/minkernel/src/UserProcessScheduler.cpp
@@ -220,18 +220,17 @@ STATIC Void sched_free_ptr_tree(T* tree) {
   // Deleting memory lists. Make sure to free all of them.
   while (tree) {
     if (tree->Entry) {
-      MUST_PASS(mm_free_ptr(tree->Entry));
+      MUST_PASS(mm_free_ptr(tree->Entry) == kErrorSuccess);
     }
 
     auto next = tree->Next;
 
-    if (next->Child) sched_free_ptr_tree(next->Child);
+    if (next && next->Child) sched_free_ptr_tree(next->Child);
 
     tree->Child = nullptr;
 
     mm_free_ptr(tree);
 
-    tree = nullptr;
     tree = next;
   }
 }
@@ -336,7 +335,8 @@ Bool UserProcess::InitDylib() {
 /// @return the process index inside the team.
 /***********************************************************************************/
 
-ProcessID UserProcessScheduler::Spawn(const Char* name, VoidPtr code, VoidPtr image) {
+ProcessID UserProcessScheduler::Spawn(const Char* name, VoidPtr code, VoidPtr image,
+                                      SizeT image_sz) {
   if (!name || !code) {
     return -kErrorProcessFault;
   }
@@ -355,8 +355,9 @@ ProcessID UserProcessScheduler::Spawn(const Char* name, VoidPtr code, VoidPtr im
 
   UserProcess& process = this->mTeam.mProcessList[pid];
 
-  process.Image.fCode = code;
-  process.Image.fBlob = image;
+  process.Image.fCode   = code;
+  process.Image.fBlob   = image;
+  process.Image.fBlobSz = image_sz;
 
   SizeT len = rt_string_len(name);
 
@@ -542,8 +543,8 @@ SizeT UserProcessScheduler::Run() {
 
 /// @brief Gets the current scheduled team.
 /// @return
-Ref<UserProcessTeam> UserProcessScheduler::TheCurrentTeam() {
-  return {mTeam};
+UserProcessTeam& UserProcessScheduler::TheCurrentTeam() {
+  return mTeam;
 }
 
 /***********************************************************************************/
@@ -653,7 +654,7 @@ Bool UserProcessHelper::Switch(HAL::StackFramePtr frame_ptr, ProcessID new_pid) 
     UserProcessHelper::TheCurrentPID().Leak().Leak() = new_pid;
 
     HardwareThreadScheduler::The()[index].Leak()->fPTime =
-        UserProcessScheduler::The().TheCurrentTeam().Leak().AsArray()[new_pid].PTime;
+        UserProcessScheduler::The().TheCurrentTeam().AsArray()[new_pid].PTime;
 
     return YES;
   }

--- a/private/minloader/src/BootThread.cpp
+++ b/private/minloader/src/BootThread.cpp
@@ -172,12 +172,14 @@ Int32 BootThread::Start(HEL::BootInfoHeader* handover, Bool own_stack) {
     return kEfiFail;
   }
 
-  NE_UNUSED(own_stack);
-
   fHandover = handover;
 
   BootTextWriter writer;
   writer.Write("BootThread: ").Write(fBlobName).Write("\r");
+
+  if (own_stack && handover->f_StackTop) {
+    rt_jump_to_address(fStartAddress, fHandover, (UInt8*) ((UIntPtr) handover->f_StackTop - 8));
+  }
 
   auto ret = ((HEL::HandoverProc)fStartAddress)(fHandover);
 

--- a/private/minloader/src/BootThread.cpp
+++ b/private/minloader/src/BootThread.cpp
@@ -78,6 +78,16 @@ BootThread::BootThread(VoidPtr blob) : fStartAddress(nullptr), fBlob(blob) {
 
     writer.Write("BootZ: Image-Base: ").Write(loadStartAddress).Write("\r");
 
+    /// @note claim the window before writing into it. Without this the firmware still
+    /// reports it as free and the kernel hands its own image out as usable memory.
+    EfiPhysicalAddress claim = loadStartAddress;
+
+    auto pages = (opt_header_ptr->SizeOfImage + 0xFFF) / 0x1000;
+
+    if (BS->AllocatePages(AllocateAddress, EfiLoaderCode, pages, &claim) != kEfiOk) {
+      writer.Write("BootZ: warning: image window is already taken.\r");
+    }
+
     LDR_SECTION_HEADER_PTR sectPtr =
         (LDR_SECTION_HEADER_PTR) (((Char*) opt_header_ptr) + header_ptr->SizeOfOptionalHeader);
 
@@ -181,7 +191,7 @@ Int32 BootThread::Start(HEL::BootInfoHeader* handover, Bool own_stack) {
     rt_jump_to_address(fStartAddress, fHandover, (UInt8*) ((UIntPtr) handover->f_StackTop - 8));
   }
 
-  auto ret = ((HEL::HandoverProc)fStartAddress)(fHandover);
+  auto ret = ((HEL::HandoverProc) fStartAddress)(fHandover);
 
   return ret;
 }

--- a/private/minloader/src/HEL/AMD64/BootEFI.cpp
+++ b/private/minloader/src/HEL/AMD64/BootEFI.cpp
@@ -16,6 +16,10 @@
 #include <modules/CoreGfx/CoreGfx.h>
 #include <modules/CoreGfx/TextGfx.h>
 
+/** Ring 0 stack handed to the kernel's TSS. */
+
+#define kBootStackSz (0x4000U)
+
 /** Graphics related. */
 
 STATIC EfiGraphicsOutputProtocol* kGop       = nullptr;
@@ -61,11 +65,11 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
 
   HEL::BootInfoHeader* handover_hdr = new HEL::BootInfoHeader();
 
-  UInt32               map_key         = 0;
-  UInt32               size_struct_ptr = sizeof(EfiMemoryDescriptor);
+  UIntPtr              map_key         = 0;
+  UIntPtr              size_struct_ptr = sizeof(EfiMemoryDescriptor);
   EfiMemoryDescriptor* struct_ptr      = nullptr;
-  UInt32               sz_desc         = sizeof(EfiMemoryDescriptor);
-  UInt32               rev_desc        = 0;
+  UIntPtr              sz_desc         = sizeof(EfiMemoryDescriptor);
+  UIntPtr              rev_desc        = 0;
 
   Boot::BootTextWriter writer;
 
@@ -132,20 +136,36 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
   handover_hdr->f_BitMapStart = nullptr; /* Start of bitmap. */
   handover_hdr->f_BitMapSize  = 0UL;     /* Size of bitmap in bytes. */
 
-  // Get memory map to determine available memory for bitmap allocation.
-  BS->GetMemoryMap(&size_struct_ptr, struct_ptr, &map_key, &sz_desc, &rev_desc);
+  // Probe for the size of the memory map.
+  size_struct_ptr = 0UL;
+  BS->GetMemoryMap(&size_struct_ptr, nullptr, &map_key, &sz_desc, &rev_desc);
 
-  // Allocate space for the memory descriptors.
-  BS->AllocatePool(EfiLoaderData, size_struct_ptr, (VoidPtr*) &struct_ptr);
-  BS->GetMemoryMap(&size_struct_ptr, struct_ptr, &map_key, &sz_desc, &rev_desc);
+  /// @note AllocatePool itself grows the map, so ask for room to spare or the
+  /// second call fails and leaves the buffer untouched.
+  size_struct_ptr += sz_desc * 8;
+
+  if (BS->AllocatePool(EfiLoaderData, size_struct_ptr, (VoidPtr*) &struct_ptr) != kEfiOk ||
+      !struct_ptr) {
+    writer.Write("BootZ: Can't allocate the memory map, can't boot to NeKernel.\r");
+    Boot::Stop();
+  }
+
+  if (BS->GetMemoryMap(&size_struct_ptr, struct_ptr, &map_key, &sz_desc, &rev_desc) != kEfiOk) {
+    writer.Write("BootZ: Can't read the memory map, can't boot to NeKernel.\r");
+    Boot::Stop();
+  }
 
   // Calculate initial bitmap size by summing all free memory pages.
   UInt64  free_pages      = 0;
-  VoidPtr first_free_page = (VoidPtr) 1024;
+  VoidPtr first_free_page = nullptr;
 
-  for (UInt32 i = 0; i < size_struct_ptr / sz_desc; ++i) {
+  constexpr UInt64 kBootLowMemEnd = 0x100000;
+
+  for (UIntPtr i = 0; i < size_struct_ptr / sz_desc; ++i) {
     EfiMemoryDescriptor* desc = (EfiMemoryDescriptor*) ((UInt8*) struct_ptr + (i * sz_desc));
     if (desc->Kind == EfiConventionalMemory) {
+      if (desc->PhysicalStart < kBootLowMemEnd) continue;
+
       if (first_free_page == nullptr) {
         first_free_page = (VoidPtr) desc->PhysicalStart;
       }
@@ -153,7 +173,12 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
     }
   }
 
-  free_pages -= 1024;
+  if (!first_free_page) {
+    writer.Write("BootZ: No conventional memory, can't boot to NeKernel.\r");
+    Boot::Stop();
+  }
+
+  free_pages = free_pages > 1024 ? free_pages - 1024 : free_pages;
 
   // Set bitmap to use the first free page region found.
   handover_hdr->f_BitMapStart = first_free_page;
@@ -163,6 +188,39 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
 
   handover_hdr->f_FirmwareCustomTables[Ne::Kernel::HEL::kHandoverTableBS] = (VoidPtr) BS;
   handover_hdr->f_FirmwareCustomTables[Ne::Kernel::HEL::kHandoverTableST] = (VoidPtr) ST;
+
+  handover_hdr->f_Magic   = kHandoverMagic;
+  handover_hdr->f_Version = kHandoverVersion;
+
+  handover_hdr->f_HardwareTables.f_ImageKey    = map_key;
+  handover_hdr->f_HardwareTables.f_ImageHandle = image_handle;
+
+  UInt32 sz_recover_mode = sizeof(Bool);
+  Bool   recover_mode    = 0;
+
+  ST->RuntimeServices->GetVariable(L"/props/recover_mode", kEfiGlobalNamespaceVarGUID, nullptr,
+                                   &sz_recover_mode, &recover_mode);
+
+  handover_hdr->f_RecoverMode = recover_mode;
+
+  recover_mode = 0;
+
+  ST->RuntimeServices->SetVariable(L"/props/recover_mode", kEfiGlobalNamespaceVarGUID, nullptr,
+                                   &sz_recover_mode, &recover_mode);
+
+  // Ring 0 stack, consumed by the kernel as TSS.RSP0. Stacks grow down, so hand over the top.
+
+  VoidPtr stack_base = nullptr;
+
+  if (BS->AllocatePool(EfiLoaderData, kBootStackSz, &stack_base) != kEfiOk || !stack_base) {
+    writer.Write("BootZ: Can't allocate the kernel stack, can't boot to NeKernel.\r");
+    Boot::Stop();
+  }
+
+  Boot::BSetMem((Char*) stack_base, 0, kBootStackSz);
+
+  handover_hdr->f_StackSz  = kBootStackSz;
+  handover_hdr->f_StackTop = (VoidPtr) (((UIntPtr) stack_base + kBootStackSz) & ~0xFUL);
 
   // ------------------------------------------ //
   // If we succeed in reading the blob, then execute it.
@@ -209,12 +267,6 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
   }
 
   handover_hdr->f_FirmwareVendorLen = Boot::BStrLen(sys_table->FirmwareVendor);
-
-  handover_hdr->f_Magic   = kHandoverMagic;
-  handover_hdr->f_Version = kHandoverVersion;
-
-  handover_hdr->f_HardwareTables.f_ImageKey    = map_key;
-  handover_hdr->f_HardwareTables.f_ImageHandle = image_handle;
 
   // Provide fimware vendor name.
 
@@ -265,20 +317,22 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
     writer.Write("BootZ: Version: ").Write(ver).Write("\r");
   }
 
-  UInt32 sz_recover_mode = sizeof(Bool);
-  Bool   recover_mode    = 0;
-
-  ST->RuntimeServices->GetVariable(L"/props/recover_mode", kEfiGlobalNamespaceVarGUID, nullptr,
-                                   &sz_recover_mode, &recover_mode);
-
-  kHandoverHeader->f_RecoverMode = recover_mode;
-
-  recover_mode = 0;
-
-  ST->RuntimeServices->SetVariable(L"/props/recover_mode", kEfiGlobalNamespaceVarGUID, nullptr,
-                                   &sz_recover_mode, &recover_mode);
-
   // boot to kernel, if not bootnet this.
+
+  Boot::BootFileReader reader_basesvc(L"basesvc.exe", image_handle);
+  reader_basesvc.ReadAll(0);
+
+  if (reader_basesvc.Blob()) {
+    handover_hdr->f_SCIImage   = reader_basesvc.Blob();
+    handover_hdr->f_SCIImageSz = reader_basesvc.Size();
+
+    writer.Write("BootZ: Loaded basesvc.exe.\r");
+  } else {
+    handover_hdr->f_SCIImage   = nullptr;
+    handover_hdr->f_SCIImageSz = 0UL;
+
+    writer.Write("BootZ: No basesvc.exe, booting without a user process.\r");
+  }
 
   Boot::BootFileReader reader_kernel(kernel_path, image_handle);
   reader_kernel.ReadAll(0);

--- a/private/minloader/src/HEL/AMD64/BootEFI.cpp
+++ b/private/minloader/src/HEL/AMD64/BootEFI.cpp
@@ -18,7 +18,7 @@
 
 /** Ring 0 stack handed to the kernel's TSS. */
 
-#define kBootStackSz (0x4000U)
+#define kBootStackSz (0x40000U)
 
 /** Graphics related. */
 

--- a/private/minloader/src/HEL/AMD64/BootEFI.cpp
+++ b/private/minloader/src/HEL/AMD64/BootEFI.cpp
@@ -161,30 +161,29 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
 
   constexpr UInt64 kBootLowMemEnd = 0x100000;
 
+  /// @note one region, not the sum of every region. Summing them yields a size the
+  /// kernel does not own the moment the map is fragmented.
   for (UIntPtr i = 0; i < size_struct_ptr / sz_desc; ++i) {
     EfiMemoryDescriptor* desc = (EfiMemoryDescriptor*) ((UInt8*) struct_ptr + (i * sz_desc));
-    if (desc->Kind == EfiConventionalMemory) {
-      if (desc->PhysicalStart < kBootLowMemEnd) continue;
 
-      if (first_free_page == nullptr) {
-        first_free_page = (VoidPtr) desc->PhysicalStart;
-      }
-      free_pages += desc->NumberOfPages;
+    if (desc->Kind != EfiConventionalMemory) continue;
+    if (desc->PhysicalStart < kBootLowMemEnd) continue;
+
+    if (desc->NumberOfPages > free_pages) {
+      free_pages      = desc->NumberOfPages;
+      first_free_page = (VoidPtr) desc->PhysicalStart;
     }
   }
 
-  if (!first_free_page) {
+  if (!first_free_page || free_pages < 1) {
     writer.Write("BootZ: No conventional memory, can't boot to NeKernel.\r");
     Boot::Stop();
   }
 
-  free_pages = free_pages > 1024 ? free_pages - 1024 : free_pages;
-
-  // Set bitmap to use the first free page region found.
   handover_hdr->f_BitMapStart = first_free_page;
+  handover_hdr->f_BitMapSize  = free_pages * 4096;
 
-  // Convert pages to bytes (assuming 4K pages) for bitmap size.
-  handover_hdr->f_BitMapSize = free_pages * 4096;
+  writer.Write("BootZ: Usable memory: ").Write(free_pages * 4096).Write("\r");
 
   handover_hdr->f_FirmwareCustomTables[Ne::Kernel::HEL::kHandoverTableBS] = (VoidPtr) BS;
   handover_hdr->f_FirmwareCustomTables[Ne::Kernel::HEL::kHandoverTableST] = (VoidPtr) ST;

--- a/private/minloader/src/HEL/AMD64/BootEFI.cpp
+++ b/private/minloader/src/HEL/AMD64/BootEFI.cpp
@@ -50,6 +50,67 @@ STATIC Bool boot_init_fb() {
 EFI_GUID kEfiGlobalNamespaceVarGUID = {
     0x8BE4DF61, 0x93CA, 0x11D2, {0xAA, 0x0D, 0x00, 0xE0, 0x98, 0x03, 0x2B, 0x8C}};
 
+/// @brief Find the largest block of free memory and hand it to the kernel.
+/// @note run this AFTER every image is placed, or the firmware still reports the
+/// memory those images occupy as free and the kernel allocates over itself.
+STATIC Void boot_scan_memory(HEL::BootInfoHeader* handover_hdr, UIntPtr* out_map_key) {
+  Boot::BootTextWriter writer;
+
+  UIntPtr              map_key         = 0;
+  UIntPtr              size_struct_ptr = 0;
+  UIntPtr              sz_desc         = sizeof(EfiMemoryDescriptor);
+  UIntPtr              rev_desc        = 0;
+  EfiMemoryDescriptor* struct_ptr      = nullptr;
+
+  BS->GetMemoryMap(&size_struct_ptr, nullptr, &map_key, &sz_desc, &rev_desc);
+
+  /// @note AllocatePool itself grows the map, so ask for room to spare or the
+  /// second call fails and leaves the buffer untouched.
+  size_struct_ptr += sz_desc * 8;
+
+  if (BS->AllocatePool(EfiLoaderData, size_struct_ptr, (VoidPtr*) &struct_ptr) != kEfiOk ||
+      !struct_ptr) {
+    writer.Write("BootZ: Can't allocate the memory map, can't boot to NeKernel.\r");
+    Boot::Stop();
+  }
+
+  if (BS->GetMemoryMap(&size_struct_ptr, struct_ptr, &map_key, &sz_desc, &rev_desc) != kEfiOk) {
+    writer.Write("BootZ: Can't read the memory map, can't boot to NeKernel.\r");
+    Boot::Stop();
+  }
+
+  UInt64  free_pages      = 0;
+  VoidPtr first_free_page = nullptr;
+
+  constexpr UInt64 kBootLowMemEnd = 0x100000;
+
+  /// @note one region, not the sum of every region. Summing them yields a size the
+  /// kernel does not own the moment the map is fragmented.
+  for (UIntPtr i = 0; i < size_struct_ptr / sz_desc; ++i) {
+    EfiMemoryDescriptor* desc = (EfiMemoryDescriptor*) ((UInt8*) struct_ptr + (i * sz_desc));
+
+    if (desc->Kind != EfiConventionalMemory) continue;
+    if (desc->PhysicalStart < kBootLowMemEnd) continue;
+
+    if (desc->NumberOfPages > free_pages) {
+      free_pages      = desc->NumberOfPages;
+      first_free_page = (VoidPtr) desc->PhysicalStart;
+    }
+  }
+
+  if (!first_free_page || free_pages < 1) {
+    writer.Write("BootZ: No conventional memory, can't boot to NeKernel.\r");
+    Boot::Stop();
+  }
+
+  handover_hdr->f_BitMapStart = first_free_page;
+  handover_hdr->f_BitMapSize  = free_pages * 4096;
+
+  if (out_map_key) *out_map_key = map_key;
+
+  writer.Write("BootZ: Usable memory: ").Write(free_pages * 4096).Write("\r");
+}
+
 /// @brief BootloaderMain EFI entrypoint.
 /// @param image_handle Handle of this image.
 /// @param sys_table The system table of it.
@@ -136,54 +197,7 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
   handover_hdr->f_BitMapStart = nullptr; /* Start of bitmap. */
   handover_hdr->f_BitMapSize  = 0UL;     /* Size of bitmap in bytes. */
 
-  // Probe for the size of the memory map.
-  size_struct_ptr = 0UL;
-  BS->GetMemoryMap(&size_struct_ptr, nullptr, &map_key, &sz_desc, &rev_desc);
-
-  /// @note AllocatePool itself grows the map, so ask for room to spare or the
-  /// second call fails and leaves the buffer untouched.
-  size_struct_ptr += sz_desc * 8;
-
-  if (BS->AllocatePool(EfiLoaderData, size_struct_ptr, (VoidPtr*) &struct_ptr) != kEfiOk ||
-      !struct_ptr) {
-    writer.Write("BootZ: Can't allocate the memory map, can't boot to NeKernel.\r");
-    Boot::Stop();
-  }
-
-  if (BS->GetMemoryMap(&size_struct_ptr, struct_ptr, &map_key, &sz_desc, &rev_desc) != kEfiOk) {
-    writer.Write("BootZ: Can't read the memory map, can't boot to NeKernel.\r");
-    Boot::Stop();
-  }
-
-  // Calculate initial bitmap size by summing all free memory pages.
-  UInt64  free_pages      = 0;
-  VoidPtr first_free_page = nullptr;
-
-  constexpr UInt64 kBootLowMemEnd = 0x100000;
-
-  /// @note one region, not the sum of every region. Summing them yields a size the
-  /// kernel does not own the moment the map is fragmented.
-  for (UIntPtr i = 0; i < size_struct_ptr / sz_desc; ++i) {
-    EfiMemoryDescriptor* desc = (EfiMemoryDescriptor*) ((UInt8*) struct_ptr + (i * sz_desc));
-
-    if (desc->Kind != EfiConventionalMemory) continue;
-    if (desc->PhysicalStart < kBootLowMemEnd) continue;
-
-    if (desc->NumberOfPages > free_pages) {
-      free_pages      = desc->NumberOfPages;
-      first_free_page = (VoidPtr) desc->PhysicalStart;
-    }
-  }
-
-  if (!first_free_page || free_pages < 1) {
-    writer.Write("BootZ: No conventional memory, can't boot to NeKernel.\r");
-    Boot::Stop();
-  }
-
-  handover_hdr->f_BitMapStart = first_free_page;
-  handover_hdr->f_BitMapSize  = free_pages * 4096;
-
-  writer.Write("BootZ: Usable memory: ").Write(free_pages * 4096).Write("\r");
+  boot_scan_memory(handover_hdr, &map_key);
 
   handover_hdr->f_FirmwareCustomTables[Ne::Kernel::HEL::kHandoverTableBS] = (VoidPtr) BS;
   handover_hdr->f_FirmwareCustomTables[Ne::Kernel::HEL::kHandoverTableST] = (VoidPtr) ST;
@@ -349,6 +363,10 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
 
     handover_hdr->f_KernelImage = reader_kernel.Blob();
     handover_hdr->f_KernelSz    = reader_kernel.Size();
+
+    boot_scan_memory(handover_hdr, &map_key);
+
+    handover_hdr->f_HardwareTables.f_ImageKey = map_key;
 
     return kernel_thread.Start(handover_hdr, YES);
   }

--- a/private/minloader/src/HEL/AMD64/BootEFI.cpp
+++ b/private/minloader/src/HEL/AMD64/BootEFI.cpp
@@ -126,11 +126,7 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
 
   HEL::BootInfoHeader* handover_hdr = new HEL::BootInfoHeader();
 
-  UIntPtr              map_key         = 0;
-  UIntPtr              size_struct_ptr = sizeof(EfiMemoryDescriptor);
-  EfiMemoryDescriptor* struct_ptr      = nullptr;
-  UIntPtr              sz_desc         = sizeof(EfiMemoryDescriptor);
-  UIntPtr              rev_desc        = 0;
+  UIntPtr map_key = 0;
 
   Boot::BootTextWriter writer;
 
@@ -208,18 +204,17 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
   handover_hdr->f_HardwareTables.f_ImageKey    = map_key;
   handover_hdr->f_HardwareTables.f_ImageHandle = image_handle;
 
-  UInt32 sz_recover_mode = sizeof(Bool);
-  Bool   recover_mode    = 0;
+  UIntPtr sz_recover_mode = sizeof(Bool);
+  Bool    recover_mode    = 0;
 
   ST->RuntimeServices->GetVariable(L"/props/recover_mode", kEfiGlobalNamespaceVarGUID, nullptr,
                                    &sz_recover_mode, &recover_mode);
 
   handover_hdr->f_RecoverMode = recover_mode;
 
-  recover_mode = 0;
-
-  ST->RuntimeServices->SetVariable(L"/props/recover_mode", kEfiGlobalNamespaceVarGUID, nullptr,
-                                   &sz_recover_mode, &recover_mode);
+  /* one shot flag, attributes 0 delete it. */
+  ST->RuntimeServices->SetVariable(L"/props/recover_mode", kEfiGlobalNamespaceVarGUID, 0, 0,
+                                   nullptr);
 
   // Ring 0 stack, consumed by the kernel as TSS.RSP0. Stacks grow down, so hand over the top.
 
@@ -290,16 +285,20 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
   // Assign to global 'kHandoverHeader'.
 
   WideChar kernel_path[256U] = L"vmkrnl.exe";
-  UInt32   kernel_path_sz    = StrLen("vmkrnl.exe");
+  UIntPtr  kernel_path_sz    = sizeof(kernel_path);
 
-  UInt32 sz_ver = sizeof(UInt64);
-  UInt64 ver    = KERNEL_VERSION_BCD;
+  /// access attributes (in order)
+  /// EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS
+  constexpr UInt32 kVarAttrs = 0x00000001 | 0x00000002 | 0x00000004;
+
+  UIntPtr sz_ver = sizeof(UInt64);
+  UInt64  ver    = KERNEL_VERSION_BCD;
 
   ST->RuntimeServices->GetVariable(L"/props/kern_ver", kEfiGlobalNamespaceVarGUID, nullptr, &sz_ver,
                                    &ver);
 
-  UInt32 sz_smp_max = sizeof(UInt64);
-  UInt64 smp_max    = 0;
+  UIntPtr sz_smp_max = sizeof(UInt64);
+  UInt64  smp_max    = 0;
 
   ST->RuntimeServices->GetVariable(L"/props/smp_max", kEfiGlobalNamespaceVarGUID, nullptr,
                                    &sz_smp_max, &smp_max);
@@ -312,19 +311,16 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
   if (ver < KERNEL_VERSION_BCD) {
     ver = KERNEL_VERSION_BCD;
 
-    ST->RuntimeServices->SetVariable(L"/props/kern_ver", kEfiGlobalNamespaceVarGUID, nullptr,
-                                     &sz_ver, &ver);
+    ST->RuntimeServices->SetVariable(L"/props/kern_ver", kEfiGlobalNamespaceVarGUID, kVarAttrs,
+                                     sizeof(UInt64), &ver);
 
     writer.Write("BootZ: Version has been updated: ").Write(ver).Write("\r");
 
     if (ST->RuntimeServices->GetVariable(L"/props/kernel_path", kEfiGlobalNamespaceVarGUID, nullptr,
                                          &kernel_path_sz, kernel_path) != kEfiOk) {
-      /// access attributes (in order)
-      /// EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS
-      UInt32 attr = 0x00000001 | 0x00000002 | 0x00000004;
-
-      ST->RuntimeServices->SetVariable(L"/props/kernel_path", kEfiGlobalNamespaceVarGUID, &attr,
-                                       &kernel_path_sz, kernel_path);
+      ST->RuntimeServices->SetVariable(L"/props/kernel_path", kEfiGlobalNamespaceVarGUID, kVarAttrs,
+                                       (Boot::BStrLen(kernel_path) + 1) * sizeof(WideChar),
+                                       kernel_path);
     }
   } else {
     writer.Write("BootZ: Version: ").Write(ver).Write("\r");

--- a/private/minloader/src/HEL/ARM64/BootEFI.cpp
+++ b/private/minloader/src/HEL/ARM64/BootEFI.cpp
@@ -97,7 +97,7 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
 
   if (mp) {
     mp->GetNumberOfProcessors(mp, &cnt_disabled, &cnt_enabled);
-    kHandoverHeader->f_NumberOfProcessors = cnt_enabled;
+    kHandoverHeader->f_NumberOfProcessors                      = cnt_enabled;
     kHandoverHeader->f_HardwareTables.f_MultiProcessingEnabled = cnt_enabled > 1;
   } else {
     kHandoverHeader->f_NumberOfProcessors                      = 1;
@@ -127,18 +127,17 @@ EFI_EXTERN_C EFI_API Int32 BootloaderMain(EfiHandlePtr image_handle, EfiSystemTa
 
   kHandoverHeader->f_FirmwareVendorLen = Boot::BStrLen(sys_table->FirmwareVendor);
 
-  UInt32 sz_recover_mode = sizeof(Bool);
-  Bool   recover_mode    = 0;
+  UIntPtr sz_recover_mode = sizeof(Bool);
+  Bool    recover_mode    = 0;
 
   ST->RuntimeServices->GetVariable(L"/props/recover_mode", kEfiGlobalNamespaceVarGUID, nullptr,
                                    &sz_recover_mode, &recover_mode);
 
   kHandoverHeader->f_RecoverMode = recover_mode;
 
-  recover_mode = 0;
-
-  ST->RuntimeServices->SetVariable(L"/props/recover_mode", kEfiGlobalNamespaceVarGUID, nullptr,
-                                   &sz_recover_mode, &recover_mode);
+  /* one shot flag, attributes 0 delete it. */
+  ST->RuntimeServices->SetVariable(L"/props/recover_mode", kEfiGlobalNamespaceVarGUID, 0, 0,
+                                   nullptr);
 
   Boot::BootFileReader reader_kernel(L"vmkrnl.exe", image_handle);
 


### PR DESCRIPTION
The loader now measures mem and hands the kernel its own ring 0 stack. The kernel builds its own page tables instead of borrowing the firmware's, backed by a new physical frame allocator, and the heap got bounds and a real free path.

Also fixed along the way ___chkstk_ms had the wrong ABI, the TSS wasn't packed so rsp0 landed at the wrong offset, the PTE bitfield was 65 bits, __cxa_guard_acquire was inverted, error-code vectors never popped, every IDT gate was open to ring 3, and the runtime variable services were typed wrong per UEFI so SetVariable never worked.

Current state: kernel boots clean, launch host spawns and dispatches, then faults cleanly at ring 3 because there's no user stack yet that plus context switch and per-process address spaces are the next milestones, in that order.
 
What known and I left alone for now is the IDT limit is off by one (pre-existing) and ThrExitMainThread has no kernel-side handler yet.

https://github.com/ne-app-eu/krnl/issues/148